### PR TITLE
[Logging] Add project logger and T201 lint rule

### DIFF
--- a/mujoco_torch/__init__.py
+++ b/mujoco_torch/__init__.py
@@ -46,6 +46,9 @@ from mujoco_torch._src.inverse import inverse
 # I/O
 from mujoco_torch._src.io import make_data
 
+# Logging
+from mujoco_torch._src.log import logger as mujoco_logger
+
 # Passive forces
 from mujoco_torch._src.passive import passive
 

--- a/mujoco_torch/_src/log.py
+++ b/mujoco_torch/_src/log.py
@@ -1,0 +1,32 @@
+# Copyright 2023 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Logging configuration for mujoco-torch."""
+
+import logging
+import os
+
+LOGGING_LEVEL = os.environ.get("MUJOCO_TORCH_LOGGING_LEVEL", "INFO")
+
+logger = logging.getLogger("mujoco_torch")
+logger.setLevel(LOGGING_LEVEL)
+logger.propagate = False
+
+while logger.hasHandlers():
+    logger.removeHandler(logger.handlers[0])
+
+_handler = logging.StreamHandler()
+_handler.setLevel(LOGGING_LEVEL)
+_handler.setFormatter(logging.Formatter("%(asctime)s [%(name)s][%(levelname)s] %(message)s"))
+logger.addHandler(_handler)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,12 +40,13 @@ line-length = 120
 
 [tool.ruff.lint]
 select = [
-    "E",   # pycodestyle errors
-    "F",   # pyflakes
-    "I",   # isort
-    "W",   # pycodestyle warnings
-    "UP",  # pyupgrade
-    "B",   # flake8-bugbear
+    "E",    # pycodestyle errors
+    "F",    # pyflakes
+    "I",    # isort
+    "W",    # pycodestyle warnings
+    "UP",   # pyupgrade
+    "B",    # flake8-bugbear
+    "T201", # no print() in library code
 ]
 ignore = [
     "E402",  # module-import-not-at-top (structural pattern in codebase)
@@ -57,3 +58,5 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
+"examples/*" = ["T201"]
+"test/*" = ["T201"]

--- a/test/log_test.py
+++ b/test/log_test.py
@@ -1,0 +1,44 @@
+# Copyright 2023 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for mujoco_torch logger."""
+
+import logging
+
+from absl.testing import absltest
+
+import mujoco_torch
+from mujoco_torch._src.log import logger
+
+
+class LoggerTest(absltest.TestCase):
+    def test_logger_name(self):
+        self.assertEqual(logger.name, "mujoco_torch")
+
+    def test_logger_has_handler(self):
+        self.assertTrue(logger.hasHandlers())
+        self.assertIsInstance(logger.handlers[0], logging.StreamHandler)
+
+    def test_logger_does_not_propagate(self):
+        self.assertFalse(logger.propagate)
+
+    def test_logger_default_level(self):
+        self.assertEqual(logger.level, logging.INFO)
+
+    def test_public_export(self):
+        self.assertIs(mujoco_torch.mujoco_logger, logger)
+
+
+if __name__ == "__main__":
+    absltest.main()


### PR DESCRIPTION
## Summary
- Create `mujoco_torch/_src/log.py` with a configurable logger (level controlled via `MUJOCO_TORCH_LOGGING_LEVEL` env var, defaults to `INFO`). Exported as `mujoco_torch.mujoco_logger` from the public API.
- Add ruff `T201` lint rule to forbid `print()` in library code, with per-file-ignores for `examples/` and `test/`.
- Add tests verifying logger name, handler, propagation, level, and public export.

## Test plan
- [x] `test/log_test.py` — 5 tests covering logger configuration and public export
- [x] `ruff check` passes across the entire codebase
- [x] `ruff format --check` passes on all changed files

Made with [Cursor](https://cursor.com)