### PR TITLE
[Imports] Remove unnecessary local imports

### DIFF
--- a/mujoco_torch/_src/device.py
+++ b/mujoco_torch/_src/device.py
@@ -24,6 +24,7 @@ from typing import Any, overload
 import mujoco
 import numpy as np
 import torch
+from torch.utils._pytree import tree_map
 
 from mujoco_torch._src import collision_driver, mesh, types
 from mujoco_torch._src.dataclasses import MjTensorClass
@@ -301,8 +302,6 @@ def device_get_into(result, value):
 
     # In PyTorch, tensors are already accessible from CPU; no device_get needed.
     # Just ensure all tensors are detached and on CPU.
-    from torch.utils._pytree import tree_map
-
     value = tree_map(
         lambda x: x.detach().cpu() if isinstance(x, torch.Tensor) else x,
         value,

--- a/mujoco_torch/_src/solver.py
+++ b/mujoco_torch/_src/solver.py
@@ -66,6 +66,7 @@ def while_loop(cond_fn, body_fn, carried_inputs, max_iter=None):
 
 
 from mujoco_torch._src import math, support
+from mujoco_torch._src.collision_driver import constraint_sizes
 
 # pylint: disable=g-importing-member
 from mujoco_torch._src.types import Data, DisableBit, Model, SolverType
@@ -312,8 +313,6 @@ def solve(m: Model, d: Data) -> Data:
     qacc_smooth = d.qacc_smooth.clone()
     qacc_warmstart = d.qacc_warmstart.clone()
     qfrc_constraint = d.qfrc_constraint.clone()
-    from mujoco_torch._src.constraint import constraint_sizes
-
     ne, nf, nl, ncon_m, nefc = constraint_sizes(m)
     ne_nf = ne + nf
 

--- a/mujoco_torch/_src/support.py
+++ b/mujoco_torch/_src/support.py
@@ -17,8 +17,9 @@
 import mujoco
 import numpy as np
 import torch
+from torch._C._functorch import _add_batch_dim, _remove_batch_dim, is_batchedtensor, maybe_get_level
 
-from mujoco_torch._src import scan
+from mujoco_torch._src import math, scan
 
 # pylint: disable=g-importing-member
 from mujoco_torch._src.types import Data, JacobianType, Model
@@ -113,16 +114,12 @@ def local_to_global(
     local_quat: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Converts local position/orientation to world frame."""
-    from mujoco_torch._src import math
-
     pos = world_pos + math.rotate(local_pos, world_quat)
     mat = math.quat_to_mat(math.quat_mul(world_quat, local_quat))
     return pos, mat
 
 
 def vmap_compatible_index_select(tensor, dim, index):
-    from torch._C._functorch import _add_batch_dim, _remove_batch_dim, is_batchedtensor, maybe_get_level
-
     scalar_index = not isinstance(index, torch.Tensor) and isinstance(index, (int, np.integer))
     if not isinstance(index, torch.Tensor):
         index = torch.tensor([index]).long() if scalar_index else torch.as_tensor(index).long()


### PR DESCRIPTION
## Summary
- Break the `constraint` <-> `collision_driver` <-> `solver` circular dependency by moving `constraint_sizes()` into `collision_driver.py` (where its only non-type dependency `make_condim` already lives). A `constraint_sizes` alias is kept in `constraint.py` for backward compatibility.
- Promote all remaining local imports to module level: `tree_map` in `device.py`, `math` and functorch internals in `support.py`, `constraint_sizes` in `solver.py`.
- Zero local imports remain in `mujoco_torch/_src/`.

## Test plan
- [x] All 248 existing tests pass (`python -m pytest test/ -v`)
- [x] `ruff check` and `ruff format --check` pass on all changed files

Made with [Cursor](https://cursor.com)