### PR TITLE
[Cleanup] Replace numpy with PyTorch in hot-path modules

### DIFF
--- a/mujoco_torch/_src/forward.py
+++ b/mujoco_torch/_src/forward.py
@@ -19,7 +19,6 @@ from collections.abc import Sequence
 import mujoco
 
 # pylint: enable=g-importing-member
-import numpy as np
 import torch
 from torch._higher_order_ops.scan import scan as _torch_scan
 
@@ -54,14 +53,14 @@ from mujoco_torch._src import (
 from mujoco_torch._src.types import BiasType, Data, DisableBit, DynType, GainType, IntegratorType, JointType, Model
 
 # RK4 tableau
-_RK4_A = np.array(
+_RK4_A = torch.tensor(
     [
         [0.5, 0.0, 0.0],
         [0.0, 0.5, 0.0],
         [0.0, 0.0, 1.0],
     ]
 )
-_RK4_B = np.array([1.0 / 6.0, 1.0 / 3.0, 1.0 / 3.0, 1.0 / 6.0])
+_RK4_B = torch.tensor([1.0 / 6.0, 1.0 / 3.0, 1.0 / 3.0, 1.0 / 6.0])
 
 
 def _position(m: Model, d: Data) -> Data:
@@ -289,9 +288,8 @@ def _rungekutta4(m: Model, d: Data) -> Data:
     """Runge-Kutta explicit order 4 integrator."""
     d_t0 = d
     # pylint: disable=invalid-name
-    A, B = _RK4_A, _RK4_B
-    A_t = torch.tensor(A, dtype=d.qpos.dtype, device=d.qpos.device)
-    B_t = torch.tensor(B, dtype=d.qpos.dtype, device=d.qpos.device)
+    A_t = _RK4_A.to(dtype=d.qpos.dtype, device=d.qpos.device)
+    B_t = _RK4_B.to(dtype=d.qpos.dtype, device=d.qpos.device)
     C = torch.tril(A_t).sum(dim=0)  # C(i) = sum_j A(i,j)
     T = d.time + C * m.opt.timestep
     # pylint: enable=invalid-name

--- a/mujoco_torch/_src/solver.py
+++ b/mujoco_torch/_src/solver.py
@@ -17,7 +17,6 @@
 from typing import NamedTuple
 
 import mujoco
-import numpy as np
 import torch
 from torch._higher_order_ops.while_loop import while_loop as _torch_while_loop
 
@@ -181,25 +180,13 @@ def _make_solve_m_fn(m: Model, d: Data):
     # Pre-convert to tensors so the loop body is pure torch ops.
     j_updates = []
     for _, vals in sorted(updates_j.items(), reverse=True):
-        arr = np.array(vals)
-        j_updates.append(
-            (
-                torch.tensor(arr[:, 0], dtype=torch.long),
-                torch.tensor(arr[:, 1], dtype=torch.long),
-                torch.tensor(arr[:, 2], dtype=torch.long),
-            )
-        )
+        arr = torch.tensor(vals, dtype=torch.long)
+        j_updates.append((arr[:, 0], arr[:, 1], arr[:, 2]))
 
     i_updates = []
     for _, vals in sorted(updates_i.items()):
-        arr = np.array(vals)
-        i_updates.append(
-            (
-                torch.tensor(arr[:, 0], dtype=torch.long),
-                torch.tensor(arr[:, 1], dtype=torch.long),
-                torch.tensor(arr[:, 2], dtype=torch.long),
-            )
-        )
+        arr = torch.tensor(vals, dtype=torch.long)
+        i_updates.append((arr[:, 0], arr[:, 1], arr[:, 2]))
 
     def solve_m_fn(x):
         # x <- inv(L') * x


### PR DESCRIPTION
## Summary

- Convert numpy operations to native PyTorch equivalents across six core modules (`forward.py`, `smooth.py`, `solver.py`, `collision_driver.py`, `constraint.py`, `sensor.py`)
- Eliminates unnecessary numpy intermediaries where results are immediately wrapped in `torch.tensor()`, reducing CPU-GPU transfers and improving `torch.compile` traceability
- `make_condim` now returns `torch.Tensor` instead of `np.ndarray`; `solver.py` no longer imports numpy at all

## Changes by file

| File | Change |
|------|--------|
| `forward.py` | RK4 constants → `torch.tensor`; use `.to()` instead of `torch.tensor(tensor)` |
| `smooth.py` | `factor_m`/`solve_m` index arrays built directly as torch; `tendon` uses `torch.repeat_interleave` |
| `solver.py` | `np.array(vals)` → `torch.tensor(vals)`; numpy import removed |
| `collision_driver.py` | `make_condim` returns `torch.Tensor`; `np.where`/`np.cumsum`/`np.ceil` → torch/math |
| `constraint.py` | `np.where`/`np.cumsum` → torch; `isinstance(x, np.ndarray)` guards → `torch.as_tensor` |
| `sensor.py` | Address arrays as torch throughout; `np.concatenate(adrs)` → `torch.cat`; `np.zeros`/`np.eye` → torch |

## Test plan

- [x] All 248 existing tests pass
- [x] Ruff lint and format clean
- [x] RK4 integration test specifically verified (no copy-construct warnings)

Made with [Cursor](https://cursor.com)