### PR TITLE
Fix dtype mismatch during partial resets

### DIFF
--- a/mujoco_torch/zoo/base.py
+++ b/mujoco_torch/zoo/base.py
@@ -130,6 +130,8 @@ class MujocoTorchEnv(EnvBase):
         # Run one step so all dtypes match what vmap(step) produces.
         dx0 = mujoco_torch.step(self.mx, dx0)
         self._dx0 = dx0
+        self._sim_dtype = self._dx0.qpos.dtype
+        self._ctrl_dtype = self._dx0.ctrl.dtype
         self._render_precomp = mujoco_torch.precompute_render_data(self.mx)
 
         _step_fn = lambda d: mujoco_torch.step(self.mx, d)  # noqa: E731
@@ -197,7 +199,7 @@ class MujocoTorchEnv(EnvBase):
         Override for partial actuation (e.g. satellite CMGs where rotors
         are held at constant speed and only gimbals are agent-controlled).
         """
-        return action
+        return action.to(self._ctrl_dtype)
 
     def _build_obs(self) -> dict:
         """Build the full observation dict, optionally including pixels."""
@@ -261,14 +263,8 @@ class MujocoTorchEnv(EnvBase):
     # TorchRL interface
     # ------------------------------------------------------------------
 
-    def _cast_batch_dtype(self, batch):
-        return batch.apply(
-            lambda value: value.to(self.dtype) if value.is_floating_point() else value,
-            call_on_nested=True,
-        )
-
     def _make_batch(self, n: int):
-        batch = self._cast_batch_dtype(self._dx0.expand(n).clone())
+        batch = self._dx0.expand(n).clone()
         noise = self.RESET_NOISE_SCALE
         if noise > 0:
             batch.qpos.add_(torch.empty_like(batch.qpos).uniform_(-noise, noise))

--- a/mujoco_torch/zoo/base.py
+++ b/mujoco_torch/zoo/base.py
@@ -261,8 +261,14 @@ class MujocoTorchEnv(EnvBase):
     # TorchRL interface
     # ------------------------------------------------------------------
 
+    def _cast_batch_dtype(self, batch):
+        return batch.apply(
+            lambda value: value.to(self.dtype) if value.is_floating_point() else value,
+            call_on_nested=True,
+        )
+
     def _make_batch(self, n: int):
-        batch = self._dx0.expand(n).clone()
+        batch = self._cast_batch_dtype(self._dx0.expand(n).clone())
         noise = self.RESET_NOISE_SCALE
         if noise > 0:
             batch.qpos.add_(torch.empty_like(batch.qpos).uniform_(-noise, noise))
@@ -323,13 +329,7 @@ class MujocoTorchEnv(EnvBase):
         if self.auto_reset:
             done_mask = done.squeeze(-1)
             if done_mask.any():
-                n_reset = done_mask.sum()
-                reset_batch = self._dx0.expand(n_reset).clone()
-                noise = self.RESET_NOISE_SCALE
-                if noise > 0:
-                    reset_batch.qpos.add_(torch.empty_like(reset_batch.qpos).uniform_(-noise, noise))
-                    reset_batch.qvel.add_(torch.empty_like(reset_batch.qvel).uniform_(-noise, noise))
-                self._dx[done_mask] = reset_batch
+                self._dx[done_mask] = self._make_batch(int(done_mask.sum()))
                 self._step_count[done_mask] = 0
 
         return TensorDict(

--- a/mujoco_torch/zoo/satellite.py
+++ b/mujoco_torch/zoo/satellite.py
@@ -98,10 +98,10 @@ class _SatelliteBase(MujocoTorchEnv):
         rotor_ctrl = torch.full(
             (*self.batch_size, self.N_GIMBALS),
             self.ROTOR_SPEED,
-            dtype=self.dtype,
+            dtype=self._ctrl_dtype,
             device=self.device,
         )
-        return torch.cat([action, rotor_ctrl], dim=-1)
+        return torch.cat([action.to(self._ctrl_dtype), rotor_ctrl], dim=-1)
 
     def _make_batch(self, n):
         batch = super()._make_batch(n)

--- a/test/zoo_reset_test.py
+++ b/test/zoo_reset_test.py
@@ -1,0 +1,114 @@
+from types import MethodType
+
+import pytest
+import torch
+from tensordict import TensorDict
+
+pytest.importorskip("mujoco")
+
+import tensordict._unbatched as _ub
+
+if not hasattr(_ub, "_HAS_WRAPPER_SUBCLASS_FIX"):
+    _ub._HAS_WRAPPER_SUBCLASS_FIX = False
+
+from mujoco_torch.zoo.base import MujocoTorchEnv
+
+
+class FakeBatch:
+    def __init__(self, qpos, qvel, ctrl):
+        self.qpos = qpos
+        self.qvel = qvel
+        self.ctrl = ctrl
+
+    def expand(self, n):
+        return FakeBatch(
+            self.qpos.expand(n, *self.qpos.shape[1:]),
+            self.qvel.expand(n, *self.qvel.shape[1:]),
+            self.ctrl.expand(n, *self.ctrl.shape[1:]),
+        )
+
+    def clone(self):
+        return FakeBatch(self.qpos.clone(), self.qvel.clone(), self.ctrl.clone())
+
+    def apply(self, fn, call_on_nested=False):
+        return FakeBatch(fn(self.qpos), fn(self.qvel), fn(self.ctrl))
+
+    def update_(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+        return self
+
+    def __setitem__(self, index, other):
+        self.qpos[index] = other.qpos
+        self.qvel[index] = other.qvel
+        self.ctrl[index] = other.ctrl
+
+
+def _make_env(*, auto_reset):
+    class DummyEnv:
+        RESET_NOISE_SCALE = 0.0
+
+    env = DummyEnv()
+    env.dtype = torch.float32
+    env.device = torch.device("cpu")
+    env.num_envs = 4
+    env.batch_size = torch.Size([4])
+    env.auto_reset = auto_reset
+    env.max_episode_steps = 5
+    env._single_env = False
+    env._physics_step = lambda data: data
+    env._dx0 = FakeBatch(
+        qpos=torch.zeros(1, 2, dtype=torch.float64),
+        qvel=torch.zeros(1, 2, dtype=torch.float64),
+        ctrl=torch.zeros(1, 1, dtype=torch.float64),
+    )
+    env._cast_batch_dtype = MethodType(MujocoTorchEnv._cast_batch_dtype, env)
+    env._make_batch = MethodType(MujocoTorchEnv._make_batch, env)
+    env._reset = MethodType(MujocoTorchEnv._reset, env)
+    env._step = MethodType(MujocoTorchEnv._step, env)
+    env._prepare_ctrl = lambda action: action
+    env._build_obs = lambda: {"observation": env._dx.qpos[..., :1].to(env.dtype)}
+    env._compute_reward = (
+        lambda qpos_before, action: torch.zeros(*env.batch_size, 1, dtype=env.dtype, device=env.device)
+    )
+    env._compute_terminated = (
+        lambda: torch.zeros(*env.batch_size, 1, dtype=torch.bool, device=env.device)
+    )
+    return env
+
+
+def test_partial_reset_preserves_float32_dtype():
+    env = _make_env(auto_reset=False)
+    env._reset()
+    env._step_count[:] = 7
+
+    env._reset(
+        TensorDict(
+            {"_reset": torch.tensor([[True], [False], [True], [False]], dtype=torch.bool)},
+            batch_size=env.batch_size,
+        )
+    )
+
+    assert env._dx.qpos.dtype == torch.float32
+    assert env._dx.qvel.dtype == torch.float32
+    assert env._dx.ctrl.dtype == torch.float32
+    assert torch.equal(env._step_count, torch.tensor([0, 7, 0, 7]))
+
+
+def test_auto_reset_preserves_float32_dtype():
+    env = _make_env(auto_reset=True)
+    env._reset()
+    env._step_count = torch.tensor([env.max_episode_steps - 1, 0, env.max_episode_steps - 1, 0], dtype=torch.long)
+
+    out = env._step(
+        TensorDict(
+            {"action": torch.zeros(4, 1, dtype=env.dtype)},
+            batch_size=env.batch_size,
+        )
+    )
+
+    assert env._dx.qpos.dtype == torch.float32
+    assert env._dx.qvel.dtype == torch.float32
+    assert env._dx.ctrl.dtype == torch.float32
+    assert out["done"].squeeze(-1).tolist() == [True, False, True, False]
+    assert torch.equal(env._step_count, torch.tensor([0, 1, 0, 1]))

--- a/test/zoo_reset_test.py
+++ b/test/zoo_reset_test.py
@@ -69,12 +69,10 @@ def _make_env(*, auto_reset):
     env._step = MethodType(MujocoTorchEnv._step, env)
     env._prepare_ctrl = MethodType(MujocoTorchEnv._prepare_ctrl, env)
     env._build_obs = lambda: {"observation": env._dx.qpos[..., :1].to(env.dtype)}
-    env._compute_reward = (
-        lambda qpos_before, action: torch.zeros(*env.batch_size, 1, dtype=env.dtype, device=env.device)
+    env._compute_reward = lambda qpos_before, action: torch.zeros(
+        *env.batch_size, 1, dtype=env.dtype, device=env.device
     )
-    env._compute_terminated = (
-        lambda: torch.zeros(*env.batch_size, 1, dtype=torch.bool, device=env.device)
-    )
+    env._compute_terminated = lambda: torch.zeros(*env.batch_size, 1, dtype=torch.bool, device=env.device)
     return env
 
 

--- a/test/zoo_reset_test.py
+++ b/test/zoo_reset_test.py
@@ -5,6 +5,7 @@ import torch
 from tensordict import TensorDict
 
 pytest.importorskip("mujoco")
+pytest.importorskip("torchrl")
 
 import tensordict._unbatched as _ub
 

--- a/test/zoo_reset_test.py
+++ b/test/zoo_reset_test.py
@@ -57,16 +57,17 @@ def _make_env(*, auto_reset):
     env.max_episode_steps = 5
     env._single_env = False
     env._physics_step = lambda data: data
+    env._ctrl_dtype = torch.float64
+    env._sim_dtype = torch.float64
     env._dx0 = FakeBatch(
         qpos=torch.zeros(1, 2, dtype=torch.float64),
         qvel=torch.zeros(1, 2, dtype=torch.float64),
         ctrl=torch.zeros(1, 1, dtype=torch.float64),
     )
-    env._cast_batch_dtype = MethodType(MujocoTorchEnv._cast_batch_dtype, env)
     env._make_batch = MethodType(MujocoTorchEnv._make_batch, env)
     env._reset = MethodType(MujocoTorchEnv._reset, env)
     env._step = MethodType(MujocoTorchEnv._step, env)
-    env._prepare_ctrl = lambda action: action
+    env._prepare_ctrl = MethodType(MujocoTorchEnv._prepare_ctrl, env)
     env._build_obs = lambda: {"observation": env._dx.qpos[..., :1].to(env.dtype)}
     env._compute_reward = (
         lambda qpos_before, action: torch.zeros(*env.batch_size, 1, dtype=env.dtype, device=env.device)
@@ -79,7 +80,7 @@ def _make_env(*, auto_reset):
 
 def test_partial_reset_preserves_float32_dtype():
     env = _make_env(auto_reset=False)
-    env._reset()
+    out = env._reset()
     env._step_count[:] = 7
 
     env._reset(
@@ -89,9 +90,10 @@ def test_partial_reset_preserves_float32_dtype():
         )
     )
 
-    assert env._dx.qpos.dtype == torch.float32
-    assert env._dx.qvel.dtype == torch.float32
-    assert env._dx.ctrl.dtype == torch.float32
+    assert out["observation"].dtype == torch.float32
+    assert env._dx.qpos.dtype == torch.float64
+    assert env._dx.qvel.dtype == torch.float64
+    assert env._dx.ctrl.dtype == torch.float64
     assert torch.equal(env._step_count, torch.tensor([0, 7, 0, 7]))
 
 
@@ -107,8 +109,9 @@ def test_auto_reset_preserves_float32_dtype():
         )
     )
 
-    assert env._dx.qpos.dtype == torch.float32
-    assert env._dx.qvel.dtype == torch.float32
-    assert env._dx.ctrl.dtype == torch.float32
+    assert out["observation"].dtype == torch.float32
+    assert env._dx.qpos.dtype == torch.float64
+    assert env._dx.qvel.dtype == torch.float64
+    assert env._dx.ctrl.dtype == torch.float64
     assert out["done"].squeeze(-1).tolist() == [True, False, True, False]
     assert torch.equal(env._step_count, torch.tensor([0, 1, 0, 1]))


### PR DESCRIPTION
## Summary
- keep MuJoCo simulator state in its native float64 dtype across full reset, partial reset, and auto-reset
- cast agent actions to the simulator control dtype at the `_prepare_ctrl` boundary instead of casting reset batches
- keep the env API dtype for observations and rewards, and add regression tests covering float32 API with float64 simulator state

## Testing
- `uv run --extra zoo --extra test pytest test/zoo_reset_test.py`
