### PR TITLE
[BugFix] Gate mesh convex precompute by collision candidates

### DIFF
--- a/mujoco_torch/_src/device.py
+++ b/mujoco_torch/_src/device.py
@@ -539,8 +539,30 @@ def _model_derived(value: mujoco.MjModel) -> dict[str, Any]:
     result = {"cache_id": _model_cache_id_counter}
     for k, v in mesh_kwargs.items():
         result[k] = tuple(torch.tensor(x) if x is not None else None for x in v)
-    # mesh_convex: one ConvexMesh per mesh
-    result["mesh_convex"] = tuple(mesh.convex(value, i) for i in range(value.nmesh))
+
+    geom_convex_data = (
+        result["geom_convex_face"],
+        result["geom_convex_vert"],
+        result["geom_convex_edge"],
+    )
+    candidate_set = collision_driver.collision_candidates(
+        value,
+        geom_convex_data=geom_convex_data,
+    )
+
+    mesh_convex: list[Any | None] = [None] * int(value.nmesh)
+    mesh_geom_type = int(types.GeomType.MESH)
+    for key, cands in candidate_set.items():
+        t1, t2 = int(key[0]), int(key[1])
+        for cand in cands:
+            for t, geom_id in ((t1, cand.geom1), (t2, cand.geom2)):
+                if t != mesh_geom_type:
+                    continue
+                data_id = int(value.geom_dataid[geom_id])
+                if data_id >= 0 and mesh_convex[data_id] is None:
+                    mesh_convex[data_id] = mesh.convex(value, data_id)
+    result["mesh_convex"] = tuple(mesh_convex)
+
     result["dof_hasfrictionloss"] = np.array(value.dof_frictionloss > 0)
     result["geom_rbound_hfield"] = np.array(value.geom_rbound)
     result["tendon_hasfrictionloss"] = np.array(value.tendon_frictionloss > 0)
@@ -573,15 +595,6 @@ def _model_derived(value: mujoco.MjModel) -> dict[str, Any]:
     result["condim_tensor_py"] = collision_driver.make_condim(value)
     result["constraint_data_py"] = _compute_constraint_data(value)
 
-    geom_convex_data = (
-        result["geom_convex_face"],
-        result["geom_convex_vert"],
-        result["geom_convex_edge"],
-    )
-    candidate_set = collision_driver.collision_candidates(
-        value,
-        geom_convex_data=geom_convex_data,
-    )
     max_cp = collision_driver._max_contact_points(value)
     collision_groups = []
     total_contacts = 0

--- a/test/device_test.py
+++ b/test/device_test.py
@@ -203,6 +203,50 @@ class ValidateInputTest(absltest.TestCase):
         mx = mujoco_torch.device_put(m)
         self.assertEqual(mx.ntendon, 1)
 
+    def test_visual_only_mesh_skips_mesh_convex_precompute(self):
+        m = mujoco.MjModel.from_xml_string("""
+        <mujoco>
+            <asset>
+            <mesh name="tet" vertex="0 0 0 1 0 0 0 1 0 0 0 1" face="0 1 2 0 1 3 0 2 3 1 2 3"/>
+            </asset>
+            <worldbody>
+            <body pos="0 0 1">
+                <freejoint/>
+                <geom type="mesh" mesh="tet" contype="0" conaffinity="0"/>
+            </body>
+            <geom type="plane" size="2 2 0.1"/>
+            </worldbody>
+        </mujoco>
+        """)
+        self.assertEqual(int(m.mesh_graphadr[0]), -1)
+
+        mx = mujoco_torch.device_put(m)
+
+        self.assertLen(mx.mesh_convex, 1)
+        self.assertIsNone(mx.mesh_convex[0])
+
+    def test_colliding_mesh_still_precomputes_mesh_convex(self):
+        m = mujoco.MjModel.from_xml_string("""
+        <mujoco>
+            <asset>
+            <mesh name="tet" vertex="0 0 0 1 0 0 0 1 0 0 0 1" face="0 1 2 0 1 3 0 2 3 1 2 3"/>
+            </asset>
+            <worldbody>
+            <geom type="plane" size="2 2 0.1"/>
+            <body pos="0 0 0.3">
+                <freejoint/>
+                <geom type="mesh" mesh="tet"/>
+            </body>
+            </worldbody>
+        </mujoco>
+        """)
+        self.assertNotEqual(int(m.mesh_graphadr[0]), -1)
+
+        mx = mujoco_torch.device_put(m)
+
+        self.assertLen(mx.mesh_convex, 1)
+        self.assertIsNotNone(mx.mesh_convex[0])
+
 
 if __name__ == "__main__":
     absltest.main()


### PR DESCRIPTION
## Description

This PR fixes a crash in model transfer when a MuJoCo model contains visual-only mesh geoms whose convex graph data is not present (i.e., `mesh_graphadr == -1`).

The previous code precomputed convex mesh data for all meshes unconditionally. For visual-only meshes, `mesh.convex` can index into an empty `mesh_graph` buffer and fail.

MuJoCo MJX handles this by [only pre-computing mesh convex data for mesh geoms that participate in collisions](https://github.com/google-deepmind/mujoco/blob/main/mjx/mujoco/mjx/_src/io.py#L340).

This PR therefore changes precompute behavior to match these semantics:
- build collision candidates first
- precompute mesh convex data only for mesh geoms that participate in collisions
- keep non-collision mesh entries as None in mesh_convex

## Test plan

- [x] `pytest test/device_test.py -x -v` passes
- [x] `ruff check .` and `ruff format --check .` clean
