### PR TITLE
[Perf] Materialize stable layouts without passthrough

### DIFF
--- a/mujoco_torch/_src/collision_driver.py
+++ b/mujoco_torch/_src/collision_driver.py
@@ -793,6 +793,10 @@ def _compute_static_contact_dict(m: Model) -> dict | None:
     }
 
 
+def _materialize_like(ref: torch.Tensor, value: torch.Tensor) -> torch.Tensor:
+    return torch.zeros_like(ref) + value
+
+
 def collision(m: Model, d: Data) -> Data:
     """Collides geometries."""
     collision_groups = m._device_precomp["collision_groups_py"]
@@ -835,40 +839,37 @@ def collision(m: Model, d: Data) -> Data:
         )
         return d
 
-    # No-topk path: sort is model-constant, so reorder fresh dist/pos/frame
-    # by the baked sort_idx and pass through d.contact's model-constant fields.
-    # This keeps the vmap output stride tied to the batched input stride,
-    # avoiding stride-0 broadcast drift that forces a recompile.
     sort_idx = torch.argsort(contact.contact_dim)
-    dist = contact.dist[sort_idx]
-    pos = contact.pos[sort_idx]
-    frame = contact.frame[sort_idx]
+    contact = contact[sort_idx]
+    ne, nf, nl, _, _ = constraint_sizes(m)
+    ns = ne + nf + nl
+    dims_t = contact.contact_dim
+    rows_per_contact = torch.where(dims_t == 1, 1, (dims_t - 1) * 2)
+    zeros = torch.zeros(1, dtype=rows_per_contact.dtype, device=rows_per_contact.device)
+    offsets = torch.cumsum(torch.cat([zeros, rows_per_contact[:-1]]), dim=0)
+    new_contact = contact.replace(efc_address=(ns + offsets).to(torch.int64))
 
-    # When static precompute exists AND we're inside torch.compile, reuse
-    # d.contact's model-constant fields so the vmap output stride tracks the
-    # batched input (prevents stride-0 drift / recompile).  Eager paths
-    # (incl. device_put(MjData) -> collision()) always take the fresh branch:
-    # d.contact may carry raw post-step data with shape == ncon_ that only
-    # coincidentally matches, and passthrough would reuse stale model fields.
-    use_passthrough = (
+    use_layout_materialization = (
         m._device_precomp.get("contact_static") is not None
         and d.contact.dist.shape[-1] == ncon_
         and torch.compiler.is_compiling()
     )
-    if use_passthrough:
-        new_contact = d.contact.replace(dist=dist, pos=pos, frame=frame)
-    else:
-        contact = contact[sort_idx]
-        ne, nf, nl, _, _ = constraint_sizes(m)
-        ns = ne + nf + nl
-        dims_t = contact.contact_dim
-        rows_per_contact = torch.where(dims_t == 1, 1, (dims_t - 1) * 2)
-        zeros = torch.zeros(1, dtype=rows_per_contact.dtype, device=rows_per_contact.device)
-        offsets = torch.cumsum(torch.cat([zeros, rows_per_contact[:-1]]), dim=0)
-        new_contact = contact.replace(efc_address=(ns + offsets).to(torch.int64))
+    if use_layout_materialization:
+        new_contact = new_contact.replace(
+            includemargin=_materialize_like(d.contact.includemargin, new_contact.includemargin),
+            friction=_materialize_like(d.contact.friction, new_contact.friction),
+            solref=_materialize_like(d.contact.solref, new_contact.solref),
+            solreffriction=_materialize_like(d.contact.solreffriction, new_contact.solreffriction),
+            solimp=_materialize_like(d.contact.solimp, new_contact.solimp),
+            contact_dim=_materialize_like(d.contact.contact_dim, new_contact.contact_dim),
+            geom1=_materialize_like(d.contact.geom1, new_contact.geom1),
+            geom2=_materialize_like(d.contact.geom2, new_contact.geom2),
+            geom=_materialize_like(d.contact.geom, new_contact.geom),
+            efc_address=_materialize_like(d.contact.efc_address, new_contact.efc_address),
+        )
 
     d.update_(
         contact=new_contact,
-        ncon=UnbatchedTensor(data=torch.full((), ncon_, dtype=torch.int32, device=dist.device)),
+        ncon=UnbatchedTensor(data=torch.full((), ncon_, dtype=torch.int32, device=contact.dist.device)),
     )
     return d

--- a/mujoco_torch/_src/io.py
+++ b/mujoco_torch/_src/io.py
@@ -169,14 +169,7 @@ def make_data(m: Model | mujoco.MjModel) -> Data:
         "ten_J": torch.zeros((m.ntendon, m.nv), dtype=DEFAULT_DTYPE),
         "wrap_obj": torch.zeros((m.nwrap, 2), dtype=torch.int32),
         "wrap_xpos": torch.zeros((m.nwrap, 6), dtype=DEFAULT_DTYPE),
-        # Use the static actuator_moment baked at device_put time when all
-        # actuator transmissions produce Model-only moment rows; otherwise
-        # init to zeros (step will populate it each call).
-        "actuator_moment": (
-            torch.as_tensor(m.actuator_moment_static_py, dtype=DEFAULT_DTYPE)
-            if m.actuator_moment_static_py is not None
-            else torch.zeros((m.nu, m.nv), dtype=DEFAULT_DTYPE)
-        ),
+        "actuator_moment": torch.zeros((m.nu, m.nv), dtype=DEFAULT_DTYPE),
         "crb": torch.zeros((m.nbody, 10), dtype=DEFAULT_DTYPE),
         # qM/qLD: dense solver returns (nv, nv); sparse keeps (nM,). Match
         # the step output so Dynamo doesn't see a shape change on call 2.

--- a/mujoco_torch/_src/smooth.py
+++ b/mujoco_torch/_src/smooth.py
@@ -584,12 +584,8 @@ def transmission(m: Model, d: Data) -> Data:
             raise RuntimeError(f"unrecognized joint type: {jnt_typ}")
 
     length = torch.stack(lengths).contiguous()
-    if m.actuator_moment_is_batched_py:
-        moment = torch.stack(moments).contiguous()
-        d.update_(actuator_length=length, actuator_moment=moment)
-    else:
-        # Moment rows are Model-only; d.actuator_moment was baked at init
-        # from the same Model values.  Skip the update so vmap doesn't emit
-        # a stride-0 broadcast that mismatches init layout.
-        d.update_(actuator_length=length)
+    moment = torch.stack(moments).contiguous()
+    if torch.compiler.is_compiling() and not m.actuator_moment_is_batched_py:
+        moment = torch.zeros_like(d.actuator_moment) + moment
+    d.update_(actuator_length=length, actuator_moment=moment)
     return d


### PR DESCRIPTION
## Summary
- restore compile throughput on `ant` and `halfcheetah` by materializing fresh contact / actuator outputs with the input layout instead of reusing previous-step values wholesale
- keep the `#68` no-recompile guarantees while avoiding the broader contact and actuator passthrough regressions
- preserve the canonical `torch.compile(torch.vmap(mujoco_torch.step, in_dims=(None, 0)), fullgraph=True)` path

## Validation
- `examples/bench_all.py --env ant --mode compile --backend torch --batch_sizes 32768`
  - `main`: `462,621 steps/s`
  - this PR: `678,563 steps/s`
- `examples/bench_all.py --env halfcheetah --mode compile --backend torch --batch_sizes 32768`
  - `main`: `1,192,066 steps/s`
  - this PR: `3,369,356 steps/s`
- `pytest -m integration test/compile_recompile_integration_test.py -v`
  - `7 passed`
- humanoid canonical probe (`B=32768`, `nsteps=50`)
  - `main`: `1,881,342 steps/s`
  - this PR: `1,859,635 steps/s`

## Notes
- I also tried narrower contact-only variants. They were faster on `ant` but still recompiled on contact stride guards (`includemargin`, then `friction`), so they were not safe to ship.
- This branch is the first one that recovers both regressed envs while keeping `unique_graphs` stable.
