### PR TITLE
Release v0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mujoco-torch"
-version = "0.1.0"
+version = "0.2.0"
 description = "MuJoCo MJX ported to PyTorch"
 license = "Apache-2.0"
 authors = [{ name = "vmoens" }]


### PR DESCRIPTION
## Summary

Bumps `pyproject.toml` from `0.1.0` → `0.2.0` and drafts the release notes below. Follow the `RELEASE.md` runbook (`pytest` + `pytest -m integration` on a CUDA GPU) before tagging `v0.2.0`.
