### PR TITLE
[Feature] Add friction loss to constraint solver

### DIFF
--- a/mujoco_torch/_src/solver.py
+++ b/mujoco_torch/_src/solver.py
@@ -332,16 +332,15 @@ def solve(m: Model, d: Data, fixed_iterations: bool = False) -> Data:
             linear_pos = (ctx.Jaref >= r * efc_frictionloss) & has_floss
             active = active & ~linear_neg & ~linear_pos
             floss_force = torch.where(
-                linear_neg, efc_frictionloss,
-                torch.where(linear_pos, -efc_frictionloss,
-                            torch.zeros_like(efc_frictionloss)),
+                linear_neg,
+                efc_frictionloss,
+                torch.where(linear_pos, -efc_frictionloss, torch.zeros_like(efc_frictionloss)),
             )
             floss_cost = (
-                (linear_neg * (-0.5 * r * efc_frictionloss * efc_frictionloss
-                               - efc_frictionloss * ctx.Jaref)).sum()
-                + (linear_pos * (-0.5 * r * efc_frictionloss * efc_frictionloss
-                                 + efc_frictionloss * ctx.Jaref)).sum()
-            )
+                linear_neg * (-0.5 * r * efc_frictionloss * efc_frictionloss - efc_frictionloss * ctx.Jaref)
+            ).sum() + (
+                linear_pos * (-0.5 * r * efc_frictionloss * efc_frictionloss + efc_frictionloss * ctx.Jaref)
+            ).sum()
 
         efc_force = efc_D * -ctx.Jaref * active + floss_force
         qfrc_con = efc_J_T @ efc_force
@@ -407,10 +406,9 @@ def solve(m: Model, d: Data, fixed_iterations: bool = False) -> Data:
                 rf = r * efc_frictionloss
                 fl_ln = (x <= -rf) & has_floss
                 fl_lp = (x >= rf) & has_floss
-                qf0 = (
-                    (fl_ln * efc_frictionloss * (-0.5 * rf - ctx.Jaref)).sum()
-                    + (fl_lp * efc_frictionloss * (-0.5 * rf + ctx.Jaref)).sum()
-                )
+                qf0 = (fl_ln * efc_frictionloss * (-0.5 * rf - ctx.Jaref)).sum() + (
+                    fl_lp * efc_frictionloss * (-0.5 * rf + ctx.Jaref)
+                ).sum()
                 qf1 = (fl_ln * (-efc_frictionloss * jv)).sum() + (fl_lp * (efc_frictionloss * jv)).sum()
                 floss_adjust = torch.stack([qf0, qf1, torch.tensor(0.0, dtype=quad.dtype, device=quad.device)])
                 active = active & ~fl_ln & ~fl_lp

--- a/mujoco_torch/_src/solver.py
+++ b/mujoco_torch/_src/solver.py
@@ -104,6 +104,7 @@ class _Context(NamedTuple):
       grad: gradient of master cost                     (nv,)
       Mgrad: M / grad                                   (nv,)
       search: linesearch vector                         (nv,)
+      active: active (quadratic) constraints            (nefc,)
       gauss: gauss Cost
       cost: constraint + Gauss cost
       prev_cost: cost from previous iter
@@ -118,6 +119,7 @@ class _Context(NamedTuple):
     grad: torch.Tensor
     Mgrad: torch.Tensor  # pylint: disable=invalid-name
     search: torch.Tensor
+    active: torch.Tensor
     gauss: torch.Tensor
     cost: torch.Tensor
     prev_cost: torch.Tensor
@@ -269,6 +271,7 @@ def solve(m: Model, d: Data, fixed_iterations: bool = False) -> Data:
     efc_J_T = efc_J.T.contiguous()  # separate tensor to avoid view aliasing
     efc_D = d.efc_D.clone()
     efc_aref = d.efc_aref.clone()
+    efc_frictionloss = d.efc_frictionloss.clone()
     qfrc_smooth = d.qfrc_smooth.clone()
     qacc_smooth = d.qacc_smooth.clone()
     qacc_warmstart = d.qacc_warmstart.clone()
@@ -302,6 +305,7 @@ def solve(m: Model, d: Data, fixed_iterations: bool = False) -> Data:
             grad=torch.zeros((nv,), dtype=dtype, device=_dev),
             Mgrad=torch.zeros((nv,), dtype=dtype, device=_dev),
             search=torch.zeros((nv,), dtype=dtype, device=_dev),
+            active=torch.zeros(nefc, dtype=torch.bool, device=_dev),
             gauss=qacc.new_zeros(()),
             cost=qacc.new_full((), float("inf")),
             prev_cost=qacc.new_zeros(()),
@@ -319,10 +323,30 @@ def solve(m: Model, d: Data, fixed_iterations: bool = False) -> Data:
         eq_fric_mask = torch.arange(active.shape[0], device=active.device) < ne_nf
         active = active | eq_fric_mask
 
-        efc_force = efc_D * -ctx.Jaref * active
+        floss_force = torch.zeros(nefc, dtype=efc_D.dtype, device=efc_D.device)
+        floss_cost = torch.tensor(0.0, dtype=efc_D.dtype, device=efc_D.device)
+        if nf > 0 and not (disableflags & DisableBit.FRICTIONLOSS):
+            has_floss = efc_frictionloss > 0
+            r = 1.0 / (efc_D + (efc_D == 0.0) * mujoco.mjMINVAL)
+            linear_neg = (ctx.Jaref <= -r * efc_frictionloss) & has_floss
+            linear_pos = (ctx.Jaref >= r * efc_frictionloss) & has_floss
+            active = active & ~linear_neg & ~linear_pos
+            floss_force = torch.where(
+                linear_neg, efc_frictionloss,
+                torch.where(linear_pos, -efc_frictionloss,
+                            torch.zeros_like(efc_frictionloss)),
+            )
+            floss_cost = (
+                (linear_neg * (-0.5 * r * efc_frictionloss * efc_frictionloss
+                               - efc_frictionloss * ctx.Jaref)).sum()
+                + (linear_pos * (-0.5 * r * efc_frictionloss * efc_frictionloss
+                                 + efc_frictionloss * ctx.Jaref)).sum()
+            )
+
+        efc_force = efc_D * -ctx.Jaref * active + floss_force
         qfrc_con = efc_J_T @ efc_force
         gauss = 0.5 * ((ctx.Ma - qfrc_smooth) * (ctx.qacc - qacc_smooth)).sum(-1)
-        cost = 0.5 * torch.sum(efc_D * ctx.Jaref * ctx.Jaref * active) + gauss
+        cost = 0.5 * torch.sum(efc_D * ctx.Jaref * ctx.Jaref * active) + gauss + floss_cost
 
         return ctx._replace(
             qfrc_constraint=qfrc_con,
@@ -330,6 +354,7 @@ def solve(m: Model, d: Data, fixed_iterations: bool = False) -> Data:
             cost=cost,
             prev_cost=ctx.cost,
             efc_force=efc_force,
+            active=active,
         )
 
     def _update_gradient(ctx):
@@ -339,10 +364,7 @@ def solve(m: Model, d: Data, fixed_iterations: bool = False) -> Data:
         if solver_type == SolverType.CG:
             mgrad = solve_m_fn(grad)
         elif solver_type == SolverType.NEWTON:
-            active = ctx.Jaref < 0
-            eq_fric_mask = torch.arange(active.shape[0], device=active.device) < ne_nf
-            active = active | eq_fric_mask
-            weighted_J_T = efc_J_T * efc_D * active
+            weighted_J_T = efc_J_T * efc_D * ctx.active
             if nv <= math._INLINE_CHOLESKY_MAX_SIZE:
                 h = dense_M + (weighted_J_T.unsqueeze(-1) * efc_J).sum(-2)
             else:
@@ -373,11 +395,28 @@ def solve(m: Model, d: Data, fixed_iterations: bool = False) -> Data:
         quad = (quad * efc_D).T
 
         def point_fn(alpha):
-            active = (ctx.Jaref + alpha * jv) < 0
+            x = ctx.Jaref + alpha * jv
+            active = x < 0
             eq_fric_mask = torch.arange(active.shape[0], device=active.device) < ne_nf
             active = active | eq_fric_mask
+
+            floss_adjust = torch.zeros(3, dtype=quad.dtype, device=quad.device)
+            if nf > 0 and not (disableflags & DisableBit.FRICTIONLOSS):
+                has_floss = efc_frictionloss > 0
+                r = 1.0 / (efc_D + (efc_D == 0.0) * mujoco.mjMINVAL)
+                rf = r * efc_frictionloss
+                fl_ln = (x <= -rf) & has_floss
+                fl_lp = (x >= rf) & has_floss
+                qf0 = (
+                    (fl_ln * efc_frictionloss * (-0.5 * rf - ctx.Jaref)).sum()
+                    + (fl_lp * efc_frictionloss * (-0.5 * rf + ctx.Jaref)).sum()
+                )
+                qf1 = (fl_ln * (-efc_frictionloss * jv)).sum() + (fl_lp * (efc_frictionloss * jv)).sum()
+                floss_adjust = torch.stack([qf0, qf1, torch.tensor(0.0, dtype=quad.dtype, device=quad.device)])
+                active = active & ~fl_ln & ~fl_lp
+
             quad_active = quad * active.unsqueeze(1)
-            quad_total = quad_gauss + torch.sum(quad_active, axis=0)
+            quad_total = quad_gauss + torch.sum(quad_active, axis=0) + floss_adjust
 
             cost = alpha * alpha * quad_total[2] + alpha * quad_total[1] + quad_total[0]
             deriv_0 = 2 * alpha * quad_total[2] + quad_total[1]

--- a/mujoco_torch/_src/test_util.py
+++ b/mujoco_torch/_src/test_util.py
@@ -26,6 +26,7 @@ TEST_FILES: list[str] = [
     "cartpole.xml",
     "convex.xml",
     "equality.xml",
+    "frictionloss_dof.xml",
     "halfcheetah.xml",
     "hopper.xml",
     "humanoid.xml",

--- a/mujoco_torch/test_data/frictionloss_dof.xml
+++ b/mujoco_torch/test_data/frictionloss_dof.xml
@@ -1,0 +1,9 @@
+<mujoco>
+  <option solver="CG" timestep="0.005"/>
+  <worldbody>
+    <body pos="0 0 1">
+      <joint type="hinge" axis="0 0 1" frictionloss="2.0" damping="0.1"/>
+      <geom type="sphere" size="0.1" mass="1"/>
+    </body>
+  </worldbody>
+</mujoco>

--- a/test/solver_test.py
+++ b/test/solver_test.py
@@ -40,9 +40,7 @@ class Solver64Test(parameterized.TestCase):
         super().tearDown()
         torch.set_default_dtype(torch.float32)
 
-    @parameterized.parameters(
-        enumerate(("ant.xml", "frictionloss_dof.xml"))
-    )
+    @parameterized.parameters(enumerate(("ant.xml", "frictionloss_dof.xml")))
     def test_cg(self, seed, fname):
         """Test mujoco_torch cg solver matches mujoco cg solver at 64 bit precision."""
         f = epath.resource_path("mujoco_torch") / "test_data" / fname

--- a/test/solver_test.py
+++ b/test/solver_test.py
@@ -40,7 +40,9 @@ class Solver64Test(parameterized.TestCase):
         super().tearDown()
         torch.set_default_dtype(torch.float32)
 
-    @parameterized.parameters(enumerate(("ant.xml",)))
+    @parameterized.parameters(
+        enumerate(("ant.xml", "frictionloss_dof.xml"))
+    )
     def test_cg(self, seed, fname):
         """Test mujoco_torch cg solver matches mujoco cg solver at 64 bit precision."""
         f = epath.resource_path("mujoco_torch") / "test_data" / fname
@@ -72,7 +74,7 @@ class Solver64Test(parameterized.TestCase):
 
 
 class SolverTest(parameterized.TestCase):
-    @parameterized.parameters(enumerate(("ant.xml",)))
+    @parameterized.parameters(enumerate(("ant.xml", "frictionloss_dof.xml")))
     def test_cg(self, seed, fname):
         """Test mujoco_torch cg solver is close to mj at 32 bit precision.
 
@@ -118,9 +120,10 @@ class SolverTest(parameterized.TestCase):
 
             self.assertLessEqual(
                 cost_mjx,
-                cost_mj * 1.01,
+                max(cost_mj * 1.01, 1e-18),
                 msg=f"mismatch: {fname} at step {i}, cost too high",
             )
+            self.assertLessEqual(dx.solver_niter[0], d.solver_niter[0])
             _assert_attr_eq(d, dx, "qfrc_constraint", i, fname, atol=1e-1, rtol=1e-1)
             _assert_attr_eq(d, dx, "qacc", i, fname, atol=1e-1, rtol=1e-1)
 

--- a/test/solver_test.py
+++ b/test/solver_test.py
@@ -21,6 +21,7 @@ from absl.testing import absltest, parameterized
 from etils import epath
 
 import mujoco_torch
+from mujoco_torch._src import solver as solver_lib
 
 
 def _assert_attr_eq(a, b, attr, step, fname, atol=1e-2, rtol=1e-2):
@@ -72,6 +73,39 @@ class Solver64Test(parameterized.TestCase):
 
 
 class SolverTest(parameterized.TestCase):
+    def test_frictionloss_slipping_saturates(self):
+        """Test frictionloss constraints saturate in the slipping regime."""
+        f = epath.resource_path("mujoco_torch") / "test_data" / "frictionloss_dof.xml"
+        m = mujoco.MjModel.from_xml_string(f.read_text())
+        mx = mujoco_torch.device_put(m)
+
+        dtype = torch.float64
+        base_updates = {
+            "efc_J": torch.tensor([[1.0]], dtype=dtype),
+            "efc_D": torch.tensor([1.0], dtype=dtype),
+            "efc_aref": torch.tensor([0.0], dtype=dtype),
+            "efc_frictionloss": torch.tensor([2.0], dtype=dtype),
+            "qM": torch.tensor([[1.0]], dtype=dtype),
+            "qLD": torch.tensor([[1.0]], dtype=dtype),
+            "qLDiagInv": torch.tensor([1.0], dtype=dtype),
+            "qfrc_constraint": torch.tensor([0.0], dtype=dtype),
+        }
+
+        for smooth_force, expected_force in ((100.0, -2.0), (-100.0, 2.0)):
+            dx = mujoco_torch.make_data(mx)
+            dx.update_(
+                **base_updates,
+                qfrc_smooth=torch.tensor([smooth_force], dtype=dtype),
+                qacc_smooth=torch.tensor([smooth_force], dtype=dtype),
+                qacc_warmstart=torch.tensor([smooth_force], dtype=dtype),
+            )
+
+            dx = solver_lib.solve(mx, dx)
+
+            np.testing.assert_allclose(dx.efc_force, [expected_force])
+            np.testing.assert_allclose(dx.qfrc_constraint, [expected_force])
+            np.testing.assert_allclose(dx.qacc, [smooth_force + expected_force])
+
     @parameterized.parameters(enumerate(("ant.xml", "frictionloss_dof.xml")))
     def test_cg(self, seed, fname):
         """Test mujoco_torch cg solver is close to mj at 32 bit precision.


### PR DESCRIPTION
## Description

This PR adds support for friction loss (dry Coulomb friction) to the constraint solver.

The code matches the [MJX](https://github.com/google-deepmind/mujoco/blob/main/mjx/mujoco/mjx/_src/solver.py#L276) implementation.

In short, when a joint is "sticking," the solver acts as a spring, applying a linear restoring force proportional to the stiffness to oppose motion: $F_{spring} = -D \cdot J\ddot{q}$. This restoring force cannot exceed the physical friction limit $f$, i.e. $$-f \le -D \cdot J\ddot{q} \le f$$. We represent it as a continuous piecewise cost function so that it's differentiable:

$$
\text{Cost}(v) = \begin{cases} 
-0.5 \cdot r \cdot f^2 - f \cdot v & \text{if } v \le -r \cdot f \quad \text{(Slipping Negative)} \\ 
0.5 \cdot D \cdot v^2 & \text{if } -r \cdot f < v < r \cdot f \quad \text{(Sticking)} \\ 
-0.5 \cdot r \cdot f^2 + f \cdot v & \text{if } v \ge r \cdot f \quad \text{(Slipping Positive)} 
\end{cases}
$$

The reason for this cost is that the restoring force applied by the solver is exactly the negative gradient of the cost function:

$$
F = \begin{cases} 
f & \text{if } v \le -r \cdot f \quad \text{(Slipping Negative)} \\ 
-D \cdot v & \text{if } -r \cdot f < v < r \cdot f \quad \text{(Sticking)} \\ 
-f & \text{if } v \ge r \cdot f \quad \text{(Slipping Positive)} 
\end{cases}
$$

So, clearly the forces respect the actual saturation limit.

## Test plan

- [x] `pytest test/ -x -v` passes
- [x] Compared output against MuJoCo C at float64 precision
- [x] `ruff check .` and `ruff format --check .` clean
