### PR TITLE
[BugFix] Populate actuator_force in forward pass for ACTUATORFRC/TENDONACTFRC

### DIFF
--- a/mujoco_torch/_src/forward.py
+++ b/mujoco_torch/_src/forward.py
@@ -215,7 +215,7 @@ def _actuation(m: Model, d: Data) -> Data:
     actfrcrange = actfrcrange[m.dof_jntid_t]
     qfrc_actuator = torch.clamp(qfrc_actuator, actfrcrange[:, 0], actfrcrange[:, 1])
 
-    d.update_(act_dot=act_dot.contiguous(), qfrc_actuator=qfrc_actuator.contiguous())
+    d.update_(act_dot=act_dot.contiguous(), qfrc_actuator=qfrc_actuator.contiguous(), actuator_force=force.contiguous())
     return d
 
 

--- a/test/sensor_test.py
+++ b/test/sensor_test.py
@@ -380,9 +380,7 @@ class SensorTest(parameterized.TestCase):
         mj_sensor = d.sensordata[: mx.nsensordata]
         mx_sensor = dx.sensordata.detach().numpy()
         np.testing.assert_allclose(mx_sensor, mj_sensor, atol=1e-3, rtol=1e-3)
-        assert np.all(np.abs(mx_sensor) > 0), (
-            f"actuator force sensors returned all zeros: {mx_sensor}"
-        )
+        assert np.all(np.abs(mx_sensor) > 0), f"actuator force sensors returned all zeros: {mx_sensor}"
 
     def test_sensor_groups_precomputed(self):
         """Pre-computed groups contain expected sensor types."""

--- a/test/sensor_test.py
+++ b/test/sensor_test.py
@@ -126,6 +126,37 @@ _FRAMEPOS_XML = """
 """
 
 
+_ACTUATOR_FRC_XML = """
+<mujoco>
+  <option timestep="0.005"/>
+  <worldbody>
+    <geom type="plane" size="3 3 0.01" margin="1"/>
+    <body name="left" pos="-0.5 0 1">
+      <joint name="h1" type="hinge" axis="0 1 0"/>
+      <geom type="sphere" size="0.1" mass="1"/>
+    </body>
+    <body name="right" pos="0.5 0 1">
+      <joint name="h2" type="hinge" axis="0 1 0"/>
+      <geom type="sphere" size="0.1" mass="1"/>
+    </body>
+  </worldbody>
+  <tendon>
+    <fixed name="t1">
+      <joint joint="h2" coef="1"/>
+    </fixed>
+  </tendon>
+  <actuator>
+    <motor name="m1" joint="h1" gear="10"/>
+    <motor name="mt" tendon="t1" gear="2"/>
+  </actuator>
+  <sensor>
+    <actuatorfrc actuator="m1"/>
+    <tendonactuatorfrc tendon="t1"/>
+  </sensor>
+</mujoco>
+"""
+
+
 def _run_forward(m, d, mx, dx):
     """Run MuJoCo and MJX forward, return (mj_data, mjx_data)."""
     mujoco.mj_forward(m, d)
@@ -331,6 +362,27 @@ class SensorTest(parameterized.TestCase):
         self.assertEqual(len(mx.sensor_groups_pos_py), 0)
         self.assertEqual(len(mx.sensor_groups_vel_py), 0)
         self.assertEqual(len(mx.sensor_groups_acc_py), 0)
+
+    def test_actuator_frc_sensors(self):
+        """ACTUATORFRC and TENDONACTFRC return non-zero values matching MuJoCo."""
+        m = mujoco.MjModel.from_xml_string(_ACTUATOR_FRC_XML)
+        d = mujoco.MjData(m)
+        mx = mujoco_torch.device_put(m)
+
+        d.ctrl[:] = np.array([1.0, 0.3])
+        qpos = torch.tensor(d.qpos.copy())
+        qvel = torch.tensor(d.qvel.copy())
+        dx = mujoco_torch.device_put(d)
+        dx = dx.replace(qpos=qpos, qvel=qvel)
+
+        d, dx = _run_forward(m, d, mx, dx)
+
+        mj_sensor = d.sensordata[: mx.nsensordata]
+        mx_sensor = dx.sensordata.detach().numpy()
+        np.testing.assert_allclose(mx_sensor, mj_sensor, atol=1e-3, rtol=1e-3)
+        assert np.all(np.abs(mx_sensor) > 0), (
+            f"actuator force sensors returned all zeros: {mx_sensor}"
+        )
 
     def test_sensor_groups_precomputed(self):
         """Pre-computed groups contain expected sensor types."""


### PR DESCRIPTION
## Description

`actuator_force` was declared in the Data type stubs and zero-initialized, but was never written during the forward pass.  This caused ACTUATORFRC and TENDONACTFRC sensors to silently return all zeros regardless of the control signal.

The fix adds `actuator_force=force.contiguous()` to the `d.update_()` call in `_actuation()`, so the field is populated with the actual clamped actuator force after gain/bias computation and forcerange clamping.

This also replicates MJX (relevant lines [here](https://github.com/google-deepmind/mujoco/blob/main/mjx/mujoco/mjx/_src/forward.py#L244-L246)).

## Test plan

- [x] `pytest test/ -x -v` passes
- [x] Compared output against MuJoCo C at float64 precision
- [x] `ruff check .` and `ruff format --check .` clean
