### PR TITLE
[Feature] Add support for frame velocity sensors

### DIFF
--- a/mujoco_torch/_src/device.py
+++ b/mujoco_torch/_src/device.py
@@ -513,6 +513,44 @@ def _compute_sensor_groups(value: mujoco.MjModel) -> dict[str, tuple]:
                     value.jnt_dofadr[objid_np, None] + np.arange(3)[None],
                     dtype=torch.long,
                 )
+            elif st_int in (SType.FRAMELINVEL, SType.FRAMEANGVEL):
+                objtype_np = value.sensor_objtype[idx]
+                reftype_np = value.sensor_reftype[idx]
+                refid_np = value.sensor_refid[idx]
+
+                _bodyid_src = {
+                    int(OType.UNKNOWN): np.arange(1),
+                    int(OType.BODY): np.arange(value.nbody),
+                    int(OType.XBODY): np.arange(value.nbody),
+                    int(OType.GEOM): value.geom_bodyid,
+                    int(OType.SITE): value.site_bodyid,
+                    int(OType.CAMERA): value.cam_bodyid,
+                }
+
+                ot_rt_groups = []
+                for ot_val, rt_val in sorted(set(zip(objtype_np, reftype_np))):
+                    idxt = (objtype_np == ot_val) & (reftype_np == rt_val)
+                    sub_objid = objid_np[idxt]
+                    sub_refid = refid_np[idxt]
+
+                    obj_bodyid_np = _bodyid_src[int(ot_val)][sub_objid]
+                    ref_bodyid_np = _bodyid_src[int(rt_val)][sub_refid]
+
+                    sub: dict = {
+                        "ot": int(ot_val),
+                        "rt": int(rt_val),
+                        "objid": torch.tensor(sub_objid, dtype=torch.long),
+                        "refid": torch.tensor(sub_refid, dtype=torch.long),
+                        "cutoff": torch.tensor(cutoff_np[idxt], dtype=torch.float64),
+                        "adr": torch.tensor(adr_np[idxt], dtype=torch.long),
+                        "obj_bodyid": torch.tensor(obj_bodyid_np, dtype=torch.long),
+                        "ref_bodyid": torch.tensor(ref_bodyid_np, dtype=torch.long),
+                        "obj_rootid": torch.tensor(value.body_rootid[obj_bodyid_np], dtype=torch.long),
+                        "ref_rootid": torch.tensor(value.body_rootid[ref_bodyid_np], dtype=torch.long),
+                    }
+                    ot_rt_groups.append(sub)
+
+                group["ot_rt_groups"] = tuple(ot_rt_groups)
 
             # -- acceleration stage extras --
             elif st_int in (SType.ACCELEROMETER, SType.FORCE, SType.TORQUE):

--- a/mujoco_torch/_src/sensor.py
+++ b/mujoco_torch/_src/sensor.py
@@ -249,6 +249,69 @@ def sensor_vel(m: Model, d: Data) -> Data:
         elif sensor_type == SensorType.SUBTREEANGMOM:
             sensor = d.subtree_angmom[objid]
             adr = (adr[:, None] + torch.arange(3, device=_dev)).reshape(-1)
+        elif sensor_type in {SensorType.FRAMELINVEL, SensorType.FRAMEANGVEL}:
+            _dev = d.qpos.device
+            _dtype = d.qpos.dtype
+            objtype_data_vel = {
+                ObjType.UNKNOWN: (
+                    torch.zeros(1, 3, dtype=_dtype, device=_dev),
+                    torch.eye(3, dtype=_dtype, device=_dev).unsqueeze(0),
+                ),
+                ObjType.BODY: (d.xipos, d.ximat),
+                ObjType.XBODY: (d.xpos, d.xmat),
+                ObjType.GEOM: (d.geom_xpos, d.geom_xmat),
+                ObjType.SITE: (d.site_xpos, d.site_xmat),
+                ObjType.CAMERA: (d.cam_xpos, d.cam_xmat),
+            }
+
+            for sub in group["ot_rt_groups"]:
+                ot, rt = sub["ot"], sub["rt"]
+                sub_objid = sub["objid"]
+                sub_refid = sub["refid"]
+                sub_cutoff = sub["cutoff"]
+                obj_bodyid = sub["obj_bodyid"]
+                ref_bodyid = sub["ref_bodyid"]
+                obj_rootid = sub["obj_rootid"]
+                ref_rootid = sub["ref_rootid"]
+
+                xpos_obj, _ = objtype_data_vel[ot]
+                xpos_ref, xmat_ref = objtype_data_vel[rt]
+                xpos_o = xpos_obj[sub_objid]
+                xpos_r = xpos_ref[sub_refid]
+                xmat_r = xmat_ref[sub_refid]
+
+                cvel_obj = d.cvel[obj_bodyid]
+                cvel_ref = d.cvel[ref_bodyid]
+                offset_obj = xpos_o - d.subtree_com[obj_rootid]
+                offset_ref = xpos_r - d.subtree_com[ref_rootid]
+
+                cangvel = cvel_obj[:, :3]
+                cangvelref = cvel_ref[:, :3]
+
+                if sensor_type == SensorType.FRAMELINVEL:
+                    clinvel = cvel_obj[:, 3:]
+                    clinvelref = cvel_ref[:, 3:]
+                    xlinvel = clinvel - math.cross(offset_obj, cangvel)
+                    xlinvelref = clinvelref - math.cross(offset_ref, cangvelref)
+                    rvec = xpos_o - xpos_r
+                    rel_vel = xlinvel - xlinvelref + math.cross(rvec, cangvelref)
+                    sensor = torch.where(
+                        (sub_refid > -1)[:, None],
+                        torch.vmap(lambda mat, vec: mat.T @ vec)(xmat_r, rel_vel),
+                        xlinvel,
+                    )
+                elif sensor_type == SensorType.FRAMEANGVEL:
+                    rel_vel = cangvel - cangvelref
+                    sensor = torch.where(
+                        (sub_refid > -1)[:, None],
+                        torch.vmap(lambda mat, vec: mat.T @ vec)(xmat_r, rel_vel),
+                        cangvel,
+                    )
+
+                adrt = sub["adr"][:, None] + torch.arange(3, device=_dev)
+                sensors.append(_apply_cutoff(sensor, sub_cutoff, data_type).reshape(-1))
+                adrs.append(adrt.reshape(-1))
+            continue
         else:
             continue
 

--- a/mujoco_torch/_src/sensor.py
+++ b/mujoco_torch/_src/sensor.py
@@ -250,7 +250,6 @@ def sensor_vel(m: Model, d: Data) -> Data:
             sensor = d.subtree_angmom[objid]
             adr = (adr[:, None] + torch.arange(3, device=_dev)).reshape(-1)
         elif sensor_type in {SensorType.FRAMELINVEL, SensorType.FRAMEANGVEL}:
-            _dev = d.qpos.device
             _dtype = d.qpos.dtype
             objtype_data_vel = {
                 ObjType.UNKNOWN: (

--- a/test/sensor_test.py
+++ b/test/sensor_test.py
@@ -45,6 +45,8 @@ _SUPPORTED_SENSOR_TYPES = {
     int(ST.BALLANGVEL),
     int(ST.SUBTREELINVEL),
     int(ST.SUBTREEANGMOM),
+    int(ST.FRAMELINVEL),
+    int(ST.FRAMEANGVEL),
     int(ST.ACCELEROMETER),
     int(ST.FORCE),
     int(ST.TORQUE),
@@ -157,6 +159,42 @@ _ACTUATOR_FRC_XML = """
 """
 
 
+_FRAMEVEL_XML = """
+<mujoco>
+  <option timestep="0.005"/>
+  <worldbody>
+    <body name="b1" pos="0 0 1">
+      <joint name="j1" type="hinge" axis="0 1 0"/>
+      <geom name="g1" type="sphere" size="0.1" mass="1" contype="0" conaffinity="0"/>
+      <site name="s1" pos="0.1 0 0"/>
+      <body name="b2" pos="0.5 0 0">
+        <joint name="j2" type="hinge" axis="0 1 0"/>
+        <geom name="g2" type="sphere" size="0.1" mass="1" contype="0" conaffinity="0"/>
+        <site name="s_ref" pos="0 0.1 0"/>
+      </body>
+    </body>
+  </worldbody>
+  <sensor>
+    <!-- site obj: no ref / site ref -->
+    <framelinvel objtype="site" objname="s1"/>
+    <framelinvel objtype="site" objname="s1" reftype="site" refname="s_ref"/>
+    <frameangvel objtype="site" objname="s1"/>
+    <frameangvel objtype="site" objname="s1" reftype="site" refname="s_ref"/>
+    <!-- body obj: no ref / body ref -->
+    <framelinvel objtype="body" objname="b1"/>
+    <framelinvel objtype="body" objname="b1" reftype="body" refname="b2"/>
+    <frameangvel objtype="body" objname="b2"/>
+    <frameangvel objtype="body" objname="b2" reftype="body" refname="b1"/>
+    <!-- geom obj: no ref / cross-type ref -->
+    <framelinvel objtype="geom" objname="g1"/>
+    <framelinvel objtype="geom" objname="g1" reftype="site" refname="s_ref"/>
+    <frameangvel objtype="geom" objname="g2"/>
+    <frameangvel objtype="geom" objname="g2" reftype="site" refname="s1"/>
+  </sensor>
+</mujoco>
+"""
+
+
 def _run_forward(m, d, mx, dx):
     """Run MuJoCo and MJX forward, return (mj_data, mjx_data)."""
     mujoco.mj_forward(m, d)
@@ -210,6 +248,29 @@ class SensorTest(parameterized.TestCase):
             atol=1e-3,
             rtol=1e-3,
             err_msg="framepos/axis sensordata mismatch",
+        )
+
+    def test_sensor_framevel(self):
+        """FRAMELINVEL/FRAMEANGVEL sensors match MuJoCo."""
+        m = mujoco.MjModel.from_xml_string(_FRAMEVEL_XML)
+        d = mujoco.MjData(m)
+        mx = mujoco_torch.device_put(m)
+
+        d.qvel[:] = np.array([1.5, 1.0])
+        qpos = torch.tensor(d.qpos.copy())
+        qvel = torch.tensor(d.qvel.copy())
+        dx = mujoco_torch.device_put(d)
+        dx = dx.replace(qpos=qpos, qvel=qvel)
+
+        d, dx = _run_forward(m, d, mx, dx)
+
+        mask = _supported_mask(m)
+        np.testing.assert_allclose(
+            dx.sensordata.detach().numpy()[mask],
+            d.sensordata[: mx.nsensordata][mask],
+            atol=1e-3,
+            rtol=1e-3,
+            err_msg="framevel sensordata mismatch",
         )
 
     @parameterized.parameters(f for f in test_util.TEST_FILES if f not in ("equality.xml",))


### PR DESCRIPTION
## Description

This PR adds support for [`FRAMELINVEL`](https://mujoco.readthedocs.io/en/stable/XMLreference.html#sensor-framelinvel) and [`FRAMEANGVEL`](https://mujoco.readthedocs.io/en/stable/XMLreference.html#sensor-frameangvel) sensors.

These sensors return the linear/angular velocity of an object compared to a reference.

The algorithm for computation of the sensor readings follows the [MJX version](https://github.com/google-deepmind/mujoco/blob/main/mjx/mujoco/mjx/_src/sensor.py#L349). In short, the absolute velocity of the object and reference are calculated by:

$$v_{\text{absolute}} = v_{\text{CoM}} + (\omega \times \vec{r})$$

(Note that Mujoco calculates the speed of an object at the subtree CoM). Then, we account for the coriolis term due to the rotating reference frame:

$$v_{\text{relative}} = v_{\text{sensor}} - v_{\text{reference}} - (\omega_{\text{reference}} \times \vec{r}_{\text{ref}\to\text{sensor}})$$

This relative velocity is in the world frame. It is then mapped to the reference body's frame. The angular velocity is calculated similarly.

The sensor groups are known at model instantiation time, and are therefore pre-computed for speed and clarity. Each object type gets its position and orientation from a different field in the `Data` structure; Therefore we separate the sensors into groups by unique object/reference type pairs and batch-calculate the sensor readings for that type pair.

## Test plan

- [x] `pytest test/sensor_test.py -x -v` passes (added a new test for new velocity sensors)
- [x] Compared output against MuJoCo C at float64 precision
- [x] `ruff check .` and `ruff format --check .` clean
