### PR TITLE
[BugFix] Keep compatibility current through MuJoCo 3.12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,12 +204,22 @@ jobs:
 
       - name: Install wheel and test deps
         run: |
+          pip install --upgrade "tensordict>=0.14.0" "torchrl>=0.14.0"
           pip install dist/*.whl
-          pip install git+https://github.com/pytorch/tensordict.git
           pip install pytest
 
       - name: Smoke test import
-        run: python -c "import mujoco_torch; print('mujoco-torch imported successfully')"
+        run: |
+          python - <<'PY'
+          import tensordict
+          import torchrl
+
+          import mujoco_torch
+
+          print(f"tensordict: {tensordict.__version__}")
+          print(f"torchrl: {torchrl.__version__}")
+          print("mujoco-torch imported successfully")
+          PY
 
   # =============================================================================
   # CREATE GITHUB RELEASE

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
         shell: bash
         run: |
           pr_matrix='{"include":[{"mujoco-version":"3.3"},{"mujoco-version":"current"}]}'
-          full_matrix='{"include":[{"mujoco-version":"3.3"},{"mujoco-version":"3.4"},{"mujoco-version":"3.5"},{"mujoco-version":"3.6"},{"mujoco-version":"3.7"},{"mujoco-version":"3.8"},{"mujoco-version":"3.9"},{"mujoco-version":"3.10"},{"mujoco-version":"current"}]}'
+          full_matrix='{"include":[{"mujoco-version":"3.3"},{"mujoco-version":"3.4"},{"mujoco-version":"3.5"},{"mujoco-version":"3.6"},{"mujoco-version":"3.7"},{"mujoco-version":"3.8"},{"mujoco-version":"3.9"},{"mujoco-version":"3.10"},{"mujoco-version":"3.11"},{"mujoco-version":"3.12"},{"mujoco-version":"current"}]}'
 
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "matrix=${pr_matrix}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,6 +69,7 @@ jobs:
         run: |
           if [[ "${REF_NAME}" == release/* || "${BASE_REF}" == release/* || "${HEAD_REF}" == release/* ]]; then
             echo "Using stable TensorDict and TorchRL from PyPI for release branch"
+            pip install --upgrade "tensordict>=0.14.0" "torchrl>=0.14.0"
           else
             echo "Installing TensorDict and TorchRL from GitHub main"
             pip install --upgrade \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,7 @@ jobs:
           else
             pip install "jax[cpu]" "mujoco==${MUJOCO_VERSION}.*" "mujoco-mjx==${MUJOCO_VERSION}.*"
           fi
-      - name: Install TensorDict
+      - name: Install PyTorch ecosystem dependencies
         env:
           BASE_REF: ${{ github.base_ref }}
           HEAD_REF: ${{ github.head_ref }}
@@ -68,11 +68,12 @@ jobs:
         shell: bash
         run: |
           if [[ "${REF_NAME}" == release/* || "${BASE_REF}" == release/* || "${HEAD_REF}" == release/* ]]; then
-            echo "Installing latest stable TensorDict from PyPI for release branch"
-            pip install --upgrade tensordict
+            echo "Using stable TensorDict and TorchRL from PyPI for release branch"
           else
-            echo "Installing TensorDict from GitHub main"
-            pip install --upgrade "tensordict @ git+https://github.com/pytorch/tensordict.git@main"
+            echo "Installing TensorDict and TorchRL from GitHub main"
+            pip install --upgrade \
+              "tensordict @ git+https://github.com/pytorch/tensordict.git@main" \
+              "torchrl @ git+https://github.com/pytorch/rl.git@main"
           fi
       - name: Install mujoco-torch with test deps
         run: pip install -e ".[test,zoo]"
@@ -83,9 +84,11 @@ jobs:
           import mujoco
           import torch
           import tensordict
+          import torchrl
 
           print(f"torch: {torch.__version__}")
           print(f"tensordict: {tensordict.__version__}")
+          print(f"torchrl: {torchrl.__version__}")
           print(f"mujoco: {mujoco.__version__}")
           print(f"mujoco-mjx: {metadata.version('mujoco-mjx')}")
           PY

--- a/README.md
+++ b/README.md
@@ -30,32 +30,31 @@ pip install -e .
 ### Requirements
 
 - Python >= 3.10
-- PyTorch (see [compatibility notes](#pytorch--tensordict-compatibility) below)
+- PyTorch (see [compatibility notes](#pytorch-tensordict--torchrl-compatibility) below)
 - MuJoCo >= 3.3, including the latest release (no upper version pin)
-- tensordict — **must be built from source or use nightlies from 2026-03-16 or
-  later** (the latest stable release will not work; see
-  [compatibility notes](#pytorch--tensordict-compatibility) below)
+- TensorDict >= 0.14.0
+- TorchRL >= 0.14.0 for the optional environment zoo
 
-### PyTorch & tensordict compatibility
+### PyTorch, TensorDict & TorchRL compatibility
 
-mujoco-torch is tested against **PyTorch nightly** and **tensordict main**.
-All modes -- eager, `torch.vmap`, and `torch.compile(fullgraph=True)` -- work
-out of the box with these versions.
+mujoco-torch development and CI track **TensorDict main** and **TorchRL main**
+together. Released installations require the 0.14 generation or newer. All
+modes -- eager, `torch.vmap`, and `torch.compile(fullgraph=True)` -- are tested
+with this aligned dependency set.
 
-> **Important:** The latest stable release of tensordict does **not** include the
-> `UnbatchedTensor` wrapper-subclass support that mujoco-torch requires.  You
-> must either install from source or use a **nightly build dated 2026-03-16 or
-> later**.
+Install the released packages with:
 
 ```bash
-# PyTorch nightly (CUDA 13.0 example; adjust the index URL for your CUDA version)
-pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu130
+pip install --upgrade "tensordict>=0.14.0" "torchrl>=0.14.0" "mujoco-torch[zoo]"
+```
 
-# Option 1: tensordict from source
-pip install git+https://github.com/pytorch/tensordict.git
+To reproduce the rolling development configuration, install TensorDict and
+TorchRL from their main branches as a pair:
 
-# Option 2: tensordict nightly (>= 2026-03-16)
-pip install --pre tensordict --index-url https://download.pytorch.org/whl/nightly/cpu
+```bash
+pip install --upgrade \
+  "tensordict @ git+https://github.com/pytorch/tensordict.git@main" \
+  "torchrl @ git+https://github.com/pytorch/rl.git@main"
 ```
 
 #### Monkey patches for upstream PyTorch PRs
@@ -71,8 +70,8 @@ The patches cover:
 
 <!-- UPSTREAM_PR_TRACKER_START -->
 - [ ] [#175526 — `while_loop` vmap batching rule](https://github.com/pytorch/pytorch/pull/175526) -- required for `torch.vmap` over the simulation loop
-- [x] [#175525 — vmap compatibility with non-tensor leaves](https://github.com/pytorch/pytorch/pull/175525) -- allows vmap to handle non-tensor outputs gracefully
-- [x] [#175852 — vmap extension points for custom container types](https://github.com/pytorch/pytorch/pull/175852) -- enables `UnbatchedTensor` to participate in vmap
+- [ ] [#175525 — vmap compatibility with non-tensor leaves](https://github.com/pytorch/pytorch/pull/175525) -- closed without merging; allows vmap to handle non-tensor outputs gracefully
+- [ ] [#175852 — vmap extension points for custom container types](https://github.com/pytorch/pytorch/pull/175852) -- closed without merging; enables `UnbatchedTensor` to participate in vmap
 - [x] [#176977 — MetaConverter storage memo for wrapper subclasses](https://github.com/pytorch/pytorch/pull/176977) -- fixes a cross-device error under `torch.compile` for `_make_wrapper_subclass` tensors
 <!-- UPSTREAM_PR_TRACKER_END -->
 

--- a/README.md
+++ b/README.md
@@ -107,8 +107,7 @@ dx = mujoco_torch.step(mx, dx)
 
 # Batched simulation with vmap
 batch_size = 4096
-envs = [mujoco_torch.device_put(mujoco.MjData(m_mj)).to("cuda")
-        for _ in range(batch_size)]
+envs = [mujoco_torch.device_put(mujoco.MjData(m_mj)).to("cuda") for _ in range(batch_size)]
 d_batch = torch.stack(envs)
 vmap_step = torch.vmap(lambda d: mujoco_torch.step(mx, d))
 d_batch = vmap_step(d_batch)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pip install -e .
 
 - Python >= 3.10
 - PyTorch (see [compatibility notes](#pytorch--tensordict-compatibility) below)
-- MuJoCo >= 3.0
+- MuJoCo >= 3.3, including the latest release (no upper version pin)
 - tensordict — **must be built from source or use nightlies from 2026-03-16 or
   later** (the latest stable release will not work; see
   [compatibility notes](#pytorch--tensordict-compatibility) below)

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -94,7 +94,7 @@ Both `bench_phase1.py` and `bench_phase2.py` have identical `clear_compile_cache
 **8. `getattr` with fallback in bench scripts**
 
 ```python
-getattr(torch._inductor.config, "cache_dir", None),
+(getattr(torch._inductor.config, "cache_dir", None),)
 ```
 
 and:
@@ -132,6 +132,7 @@ The diff adds a `_groups_to_device` helper function at the top of `sensor.py` bu
 
 ```python
 from etils import epath
+
 xml = (epath.resource_path("mujoco_torch") / "test_data" / f"{MODEL}.xml").read_text()
 ```
 

--- a/examples/torchrl_example.py
+++ b/examples/torchrl_example.py
@@ -9,7 +9,7 @@ On GPU, wrap the vmap step with ``torch.compile`` for further speedups --
 see ``examples/batched_comparison.py``.
 
 Run:
-    pip install torchrl
+    pip install -e ".[zoo]"
     python examples/torchrl_example.py
     python examples/torchrl_example.py --model cheetah
 """

--- a/mujoco_torch/_src/constraint.py
+++ b/mujoco_torch/_src/constraint.py
@@ -14,8 +14,6 @@
 # ==============================================================================
 """Core non-smooth constraint functions."""
 
-from typing import NamedTuple
-
 import mujoco
 
 # pylint: enable=g-importing-member
@@ -52,10 +50,11 @@ def _vmap_index(tensor: torch.Tensor, idx: torch.Tensor) -> torch.Tensor:
 # pylint: disable=g-importing-member
 from torch.utils._pytree import tree_map
 
-from mujoco_torch._src.types import ConeType, Data, Model
+from mujoco_torch._src.dataclasses import MjTensorClass
+from mujoco_torch._src.types import ConeType, Contact, Data, Model
 
 
-class _Efc(NamedTuple):
+class _Efc(MjTensorClass):
     """Support data for creating constraint matrices."""
 
     J: torch.Tensor
@@ -153,6 +152,7 @@ def _instantiate_equality_connect(m: Model, d: Data, precomp: dict) -> _Efc:
         solref=solref,
         solimp=solimp,
         frictionloss=frictionloss,
+        batch_size=[j.shape[0]],
     )
 
 
@@ -208,6 +208,7 @@ def _instantiate_equality_weld(m: Model, d: Data, precomp: dict) -> _Efc:
         solref=solref,
         solimp=solimp,
         frictionloss=frictionloss,
+        batch_size=[j.shape[0]],
     )
 
 
@@ -246,6 +247,7 @@ def _instantiate_friction(m: Model, d: Data, precomp: dict) -> _Efc:
         solref=solref,
         solimp=solimp,
         frictionloss=frictionloss,
+        batch_size=[size],
     )
 
 
@@ -293,6 +295,7 @@ def _instantiate_equality_joint(m: Model, d: Data, precomp: dict) -> _Efc:
         solref=solref,
         solimp=solimp,
         frictionloss=frictionloss,
+        batch_size=[j.shape[0]],
     )
 
 
@@ -328,6 +331,7 @@ def _instantiate_limit_ball(m: Model, d: Data, precomp: dict) -> _Efc:
         solref=solref,
         solimp=solimp,
         frictionloss=frictionloss,
+        batch_size=[j.shape[0]],
     )
 
 
@@ -364,6 +368,7 @@ def _instantiate_limit_slide_hinge(m: Model, d: Data, precomp: dict) -> _Efc:
         solref=solref,
         solimp=solimp,
         frictionloss=frictionloss,
+        batch_size=[j.shape[0]],
     )
 
 
@@ -396,6 +401,7 @@ def _instantiate_limit_tendon(m: Model, d: Data, precomp: dict) -> _Efc:
         solref=solref,
         solimp=solimp,
         frictionloss=frictionloss,
+        batch_size=[j.shape[0]],
     )
 
 
@@ -408,17 +414,17 @@ def _instantiate_contact_frictionless(m: Model, d: Data) -> _Efc:
     ncon_fl = m.condim_counts_py[0]
 
     @torch.vmap
-    def fn(dist, includemargin, geom1, geom2, pos, frame):
-        dist = dist - includemargin
-        g1 = geom1.long().unsqueeze(0)
-        g2 = geom2.long().unsqueeze(0)
+    def fn(c: Contact):
+        dist = c.dist - c.includemargin
+        g1 = c.geom1.long().unsqueeze(0)
+        g2 = c.geom2.long().unsqueeze(0)
         body1 = m.geom_bodyid_t.gather(0, g1).squeeze(0)
         body2 = m.geom_bodyid_t.gather(0, g2).squeeze(0)
-        diff = support.jac_dif_pair(m, d, pos, body1, body2)
+        diff = support.jac_dif_pair(m, d, c.pos, body1, body2)
         invweight0 = m.body_invweight0[:, 0]
         t = invweight0.gather(0, body1.unsqueeze(0)).squeeze(0) + invweight0.gather(0, body2.unsqueeze(0)).squeeze(0)
 
-        j = (frame @ diff.T)[0]
+        j = (c.frame @ diff.T)[0]
 
         active = dist < cfg.cfd_width if cfg.cfd else dist < 0
         return j * active, dist * active, t
@@ -428,14 +434,7 @@ def _instantiate_contact_frictionless(m: Model, d: Data) -> _Efc:
         contact = contact.clone(recurse=False)
         contact.auto_batch_size_()
     contact = contact[:ncon_fl]
-    j, pos, invweight = fn(
-        contact.dist,
-        contact.includemargin,
-        contact.geom1,
-        contact.geom2,
-        contact.pos,
-        contact.frame,
-    )
+    j, pos, invweight = fn(contact)
     solref = contact.solref
     solimp = contact.solimp
     frictionloss = torch.zeros_like(pos)
@@ -448,6 +447,7 @@ def _instantiate_contact_frictionless(m: Model, d: Data) -> _Efc:
         solref=solref,
         solimp=solimp,
         frictionloss=frictionloss,
+        batch_size=[j.shape[0]],
     )
 
 
@@ -461,36 +461,36 @@ def _instantiate_contact_pyramidal(m: Model, d: Data, condim: int, start_idx: in
     n_edges = (condim - 1) * 2
 
     @torch.vmap
-    def fn(dist, includemargin, geom1, geom2, pos, frame, friction, solref, solimp):
-        dist = dist - includemargin
-        g1 = geom1.long().unsqueeze(0)
-        g2 = geom2.long().unsqueeze(0)
+    def fn(c: Contact):
+        dist = c.dist - c.includemargin
+        g1 = c.geom1.long().unsqueeze(0)
+        g2 = c.geom2.long().unsqueeze(0)
         body1 = m.geom_bodyid_t.gather(0, g1).squeeze(0)
         body2 = m.geom_bodyid_t.gather(0, g2).squeeze(0)
 
-        jacp2, jacr2 = support.jac(m, d, pos, body2)
-        jacp1, jacr1 = support.jac(m, d, pos, body1)
-        diff = frame @ (jacp2 - jacp1).T
+        jacp2, jacr2 = support.jac(m, d, c.pos, body2)
+        jacp1, jacr1 = support.jac(m, d, c.pos, body1)
+        diff = c.frame @ (jacp2 - jacp1).T
         if condim > 3:
-            diff = torch.cat((diff, frame @ (jacr2 - jacr1).T), dim=0)
+            diff = torch.cat((diff, c.frame @ (jacr2 - jacr1).T), dim=0)
 
         invweight0 = m.body_invweight0[:, 0]
         t = invweight0.gather(0, body1.unsqueeze(0)).squeeze(0) + invweight0.gather(0, body2.unsqueeze(0)).squeeze(0)
 
-        fri = friction[: condim - 1].repeat_interleave(2)
+        fri = c.friction[: condim - 1].repeat_interleave(2)
         fri = fri * _PYRAMID_SIGNS[condim].get(fri.dtype, fri.device)
         j = diff[0] + diff[1:condim].repeat_interleave(2, dim=0) * fri.unsqueeze(1)
 
         # MuJoCo C uses mu = friction[0] for all pyramid-edge invweights,
         # regardless of per-direction coefficients (mj_constraint.c).
-        mu = friction[0]
+        mu = c.friction[0]
         invweight = (t + mu * mu * t) * 2 * mu * mu / m.opt.impratio
 
         active = dist < cfg.cfd_width if cfg.cfd else dist < 0
         j = j * active
         pos = dist.unsqueeze(0).expand(n_edges) * active
-        solref = torch.tile(solref, (n_edges, 1))
-        solimp = torch.tile(solimp, (n_edges, 1))
+        solref = torch.tile(c.solref, (n_edges, 1))
+        solimp = torch.tile(c.solimp, (n_edges, 1))
         invweight = invweight.expand(n_edges)
 
         return j, invweight, pos, solref, solimp
@@ -500,17 +500,7 @@ def _instantiate_contact_pyramidal(m: Model, d: Data, condim: int, start_idx: in
         contact = contact.clone(recurse=False)
         contact.auto_batch_size_()
     contact = contact[start_idx : start_idx + count]
-    res = fn(
-        contact.dist,
-        contact.includemargin,
-        contact.geom1,
-        contact.geom2,
-        contact.pos,
-        contact.frame,
-        contact.friction,
-        contact.solref,
-        contact.solimp,
-    )
+    res = fn(contact)
     j, invweight, pos, solref, solimp = torch.utils._pytree.tree_map(lambda x: x.reshape(-1, *x.shape[2:]), res)
     frictionloss = torch.zeros_like(pos)
 
@@ -522,6 +512,7 @@ def _instantiate_contact_pyramidal(m: Model, d: Data, condim: int, start_idx: in
         solref=solref,
         solimp=solimp,
         frictionloss=frictionloss,
+        batch_size=[j.shape[0]],
     )
 
 
@@ -533,27 +524,27 @@ def _instantiate_contact_elliptic(m: Model, d: Data, condim: int, start_idx: int
     cfg = get_diff_config()
 
     @torch.vmap
-    def fn(dist, includemargin, geom1, geom2, pos, frame, friction, solref, solimp, solreffriction):
-        dist = dist - includemargin
-        g1 = geom1.long().unsqueeze(0)
-        g2 = geom2.long().unsqueeze(0)
+    def fn(c: Contact):
+        dist = c.dist - c.includemargin
+        g1 = c.geom1.long().unsqueeze(0)
+        g2 = c.geom2.long().unsqueeze(0)
         body1 = m.geom_bodyid_t.gather(0, g1).squeeze(0)
         body2 = m.geom_bodyid_t.gather(0, g2).squeeze(0)
 
-        jacp2, jacr2 = support.jac(m, d, pos, body2)
-        jacp1, jacr1 = support.jac(m, d, pos, body1)
-        j = frame @ (jacp2 - jacp1).T
+        jacp2, jacr2 = support.jac(m, d, c.pos, body2)
+        jacp1, jacr1 = support.jac(m, d, c.pos, body1)
+        j = c.frame @ (jacp2 - jacp1).T
         if condim > 3:
-            j = torch.cat((j, (frame @ (jacr2 - jacr1).T)[: condim - 3]), dim=0)
+            j = torch.cat((j, (c.frame @ (jacr2 - jacr1).T)[: condim - 3]), dim=0)
 
         invweight0 = m.body_invweight0[:, 0]
         t = invweight0.gather(0, body1.unsqueeze(0)).squeeze(0) + invweight0.gather(0, body2.unsqueeze(0)).squeeze(0)
 
-        solreffriction = solreffriction + solref * ~solreffriction.any()
+        solreffriction = c.solreffriction + c.solref * ~c.solreffriction.any()
         solreffriction = solreffriction.unsqueeze(0).expand(condim - 1, -1)
-        solref = torch.cat((solref.unsqueeze(0), solreffriction), dim=0)
+        solref = torch.cat((c.solref.unsqueeze(0), solreffriction), dim=0)
 
-        fri = torch.square(friction[0]) / torch.square(friction[1 : condim - 1])
+        fri = torch.square(c.friction[0]) / torch.square(c.friction[1 : condim - 1])
         iw_normal = t.unsqueeze(0)
         iw_friction = (t / m.opt.impratio).unsqueeze(0)
         invweight = torch.cat((iw_normal, iw_friction, iw_friction * fri))
@@ -561,7 +552,7 @@ def _instantiate_contact_elliptic(m: Model, d: Data, condim: int, start_idx: int
         pos_aref = torch.zeros(condim, dtype=dist.dtype, device=dist.device)
         pos_aref = pos_aref.scatter(0, torch.zeros(1, dtype=torch.long, device=dist.device), dist.unsqueeze(0))
 
-        solimp = solimp.unsqueeze(0).expand(condim, -1)
+        solimp = c.solimp.unsqueeze(0).expand(condim, -1)
 
         active = dist < cfg.cfd_width if cfg.cfd else dist < 0
         j = j * active
@@ -574,18 +565,7 @@ def _instantiate_contact_elliptic(m: Model, d: Data, condim: int, start_idx: int
         contact = contact.clone(recurse=False)
         contact.auto_batch_size_()
     contact = contact[start_idx : start_idx + count]
-    res = fn(
-        contact.dist,
-        contact.includemargin,
-        contact.geom1,
-        contact.geom2,
-        contact.pos,
-        contact.frame,
-        contact.friction,
-        contact.solref,
-        contact.solimp,
-        contact.solreffriction,
-    )
+    res = fn(contact)
     j, invweight, pos, pos_norm, solref, solimp = torch.utils._pytree.tree_map(
         lambda x: x.reshape(-1, *x.shape[2:]), res
     )
@@ -599,6 +579,7 @@ def _instantiate_contact_elliptic(m: Model, d: Data, condim: int, start_idx: int
         solref=solref,
         solimp=solimp,
         frictionloss=frictionloss,
+        batch_size=[j.shape[0]],
     )
 
 
@@ -696,7 +677,7 @@ def make_constraint(m: Model, d: Data) -> Data:
         padded_nefc = nefc if torch.compiler.is_compiling() else 0
         return _set_constraint_tensors(padded_nefc)
 
-    efc = _Efc(*(torch.cat([getattr(item, field) for item in efcs]) for field in _Efc._fields))
+    efc = torch.cat(list(efcs))
     refsafe = precomp["refsafe"]
 
     @torch.vmap

--- a/mujoco_torch/_src/constraint.py
+++ b/mujoco_torch/_src/constraint.py
@@ -52,7 +52,7 @@ def _vmap_index(tensor: torch.Tensor, idx: torch.Tensor) -> torch.Tensor:
 # pylint: disable=g-importing-member
 from torch.utils._pytree import tree_map
 
-from mujoco_torch._src.types import ConeType, Contact, Data, Model
+from mujoco_torch._src.types import ConeType, Data, Model
 
 
 class _Efc(NamedTuple):
@@ -408,17 +408,17 @@ def _instantiate_contact_frictionless(m: Model, d: Data) -> _Efc:
     ncon_fl = m.condim_counts_py[0]
 
     @torch.vmap
-    def fn(c: Contact):
-        dist = c.dist - c.includemargin
-        g1 = c.geom1.long().unsqueeze(0)
-        g2 = c.geom2.long().unsqueeze(0)
+    def fn(dist, includemargin, geom1, geom2, pos, frame):
+        dist = dist - includemargin
+        g1 = geom1.long().unsqueeze(0)
+        g2 = geom2.long().unsqueeze(0)
         body1 = m.geom_bodyid_t.gather(0, g1).squeeze(0)
         body2 = m.geom_bodyid_t.gather(0, g2).squeeze(0)
-        diff = support.jac_dif_pair(m, d, c.pos, body1, body2)
+        diff = support.jac_dif_pair(m, d, pos, body1, body2)
         invweight0 = m.body_invweight0[:, 0]
         t = invweight0.gather(0, body1.unsqueeze(0)).squeeze(0) + invweight0.gather(0, body2.unsqueeze(0)).squeeze(0)
 
-        j = (c.frame @ diff.T)[0]
+        j = (frame @ diff.T)[0]
 
         active = dist < cfg.cfd_width if cfg.cfd else dist < 0
         return j * active, dist * active, t
@@ -428,7 +428,14 @@ def _instantiate_contact_frictionless(m: Model, d: Data) -> _Efc:
         contact = contact.clone(recurse=False)
         contact.auto_batch_size_()
     contact = contact[:ncon_fl]
-    j, pos, invweight = fn(contact)
+    j, pos, invweight = fn(
+        contact.dist,
+        contact.includemargin,
+        contact.geom1,
+        contact.geom2,
+        contact.pos,
+        contact.frame,
+    )
     solref = contact.solref
     solimp = contact.solimp
     frictionloss = torch.zeros_like(pos)
@@ -454,36 +461,36 @@ def _instantiate_contact_pyramidal(m: Model, d: Data, condim: int, start_idx: in
     n_edges = (condim - 1) * 2
 
     @torch.vmap
-    def fn(c: Contact):
-        dist = c.dist - c.includemargin
-        g1 = c.geom1.long().unsqueeze(0)
-        g2 = c.geom2.long().unsqueeze(0)
+    def fn(dist, includemargin, geom1, geom2, pos, frame, friction, solref, solimp):
+        dist = dist - includemargin
+        g1 = geom1.long().unsqueeze(0)
+        g2 = geom2.long().unsqueeze(0)
         body1 = m.geom_bodyid_t.gather(0, g1).squeeze(0)
         body2 = m.geom_bodyid_t.gather(0, g2).squeeze(0)
 
-        jacp2, jacr2 = support.jac(m, d, c.pos, body2)
-        jacp1, jacr1 = support.jac(m, d, c.pos, body1)
-        diff = c.frame @ (jacp2 - jacp1).T
+        jacp2, jacr2 = support.jac(m, d, pos, body2)
+        jacp1, jacr1 = support.jac(m, d, pos, body1)
+        diff = frame @ (jacp2 - jacp1).T
         if condim > 3:
-            diff = torch.cat((diff, c.frame @ (jacr2 - jacr1).T), dim=0)
+            diff = torch.cat((diff, frame @ (jacr2 - jacr1).T), dim=0)
 
         invweight0 = m.body_invweight0[:, 0]
         t = invweight0.gather(0, body1.unsqueeze(0)).squeeze(0) + invweight0.gather(0, body2.unsqueeze(0)).squeeze(0)
 
-        fri = c.friction[: condim - 1].repeat_interleave(2)
+        fri = friction[: condim - 1].repeat_interleave(2)
         fri = fri * _PYRAMID_SIGNS[condim].get(fri.dtype, fri.device)
         j = diff[0] + diff[1:condim].repeat_interleave(2, dim=0) * fri.unsqueeze(1)
 
         # MuJoCo C uses mu = friction[0] for all pyramid-edge invweights,
         # regardless of per-direction coefficients (mj_constraint.c).
-        mu = c.friction[0]
+        mu = friction[0]
         invweight = (t + mu * mu * t) * 2 * mu * mu / m.opt.impratio
 
         active = dist < cfg.cfd_width if cfg.cfd else dist < 0
         j = j * active
         pos = dist.unsqueeze(0).expand(n_edges) * active
-        solref = torch.tile(c.solref, (n_edges, 1))
-        solimp = torch.tile(c.solimp, (n_edges, 1))
+        solref = torch.tile(solref, (n_edges, 1))
+        solimp = torch.tile(solimp, (n_edges, 1))
         invweight = invweight.expand(n_edges)
 
         return j, invweight, pos, solref, solimp
@@ -493,7 +500,17 @@ def _instantiate_contact_pyramidal(m: Model, d: Data, condim: int, start_idx: in
         contact = contact.clone(recurse=False)
         contact.auto_batch_size_()
     contact = contact[start_idx : start_idx + count]
-    res = fn(contact)
+    res = fn(
+        contact.dist,
+        contact.includemargin,
+        contact.geom1,
+        contact.geom2,
+        contact.pos,
+        contact.frame,
+        contact.friction,
+        contact.solref,
+        contact.solimp,
+    )
     j, invweight, pos, solref, solimp = torch.utils._pytree.tree_map(lambda x: x.reshape(-1, *x.shape[2:]), res)
     frictionloss = torch.zeros_like(pos)
 
@@ -516,27 +533,27 @@ def _instantiate_contact_elliptic(m: Model, d: Data, condim: int, start_idx: int
     cfg = get_diff_config()
 
     @torch.vmap
-    def fn(c: Contact):
-        dist = c.dist - c.includemargin
-        g1 = c.geom1.long().unsqueeze(0)
-        g2 = c.geom2.long().unsqueeze(0)
+    def fn(dist, includemargin, geom1, geom2, pos, frame, friction, solref, solimp, solreffriction):
+        dist = dist - includemargin
+        g1 = geom1.long().unsqueeze(0)
+        g2 = geom2.long().unsqueeze(0)
         body1 = m.geom_bodyid_t.gather(0, g1).squeeze(0)
         body2 = m.geom_bodyid_t.gather(0, g2).squeeze(0)
 
-        jacp2, jacr2 = support.jac(m, d, c.pos, body2)
-        jacp1, jacr1 = support.jac(m, d, c.pos, body1)
-        j = c.frame @ (jacp2 - jacp1).T
+        jacp2, jacr2 = support.jac(m, d, pos, body2)
+        jacp1, jacr1 = support.jac(m, d, pos, body1)
+        j = frame @ (jacp2 - jacp1).T
         if condim > 3:
-            j = torch.cat((j, (c.frame @ (jacr2 - jacr1).T)[: condim - 3]), dim=0)
+            j = torch.cat((j, (frame @ (jacr2 - jacr1).T)[: condim - 3]), dim=0)
 
         invweight0 = m.body_invweight0[:, 0]
         t = invweight0.gather(0, body1.unsqueeze(0)).squeeze(0) + invweight0.gather(0, body2.unsqueeze(0)).squeeze(0)
 
-        solreffriction = c.solreffriction + c.solref * ~c.solreffriction.any()
+        solreffriction = solreffriction + solref * ~solreffriction.any()
         solreffriction = solreffriction.unsqueeze(0).expand(condim - 1, -1)
-        solref = torch.cat((c.solref.unsqueeze(0), solreffriction), dim=0)
+        solref = torch.cat((solref.unsqueeze(0), solreffriction), dim=0)
 
-        fri = torch.square(c.friction[0]) / torch.square(c.friction[1 : condim - 1])
+        fri = torch.square(friction[0]) / torch.square(friction[1 : condim - 1])
         iw_normal = t.unsqueeze(0)
         iw_friction = (t / m.opt.impratio).unsqueeze(0)
         invweight = torch.cat((iw_normal, iw_friction, iw_friction * fri))
@@ -544,7 +561,7 @@ def _instantiate_contact_elliptic(m: Model, d: Data, condim: int, start_idx: int
         pos_aref = torch.zeros(condim, dtype=dist.dtype, device=dist.device)
         pos_aref = pos_aref.scatter(0, torch.zeros(1, dtype=torch.long, device=dist.device), dist.unsqueeze(0))
 
-        solimp = c.solimp.unsqueeze(0).expand(condim, -1)
+        solimp = solimp.unsqueeze(0).expand(condim, -1)
 
         active = dist < cfg.cfd_width if cfg.cfd else dist < 0
         j = j * active
@@ -557,7 +574,18 @@ def _instantiate_contact_elliptic(m: Model, d: Data, condim: int, start_idx: int
         contact = contact.clone(recurse=False)
         contact.auto_batch_size_()
     contact = contact[start_idx : start_idx + count]
-    res = fn(contact)
+    res = fn(
+        contact.dist,
+        contact.includemargin,
+        contact.geom1,
+        contact.geom2,
+        contact.pos,
+        contact.frame,
+        contact.friction,
+        contact.solref,
+        contact.solimp,
+        contact.solreffriction,
+    )
     j, invweight, pos, pos_norm, solref, solimp = torch.utils._pytree.tree_map(
         lambda x: x.reshape(-1, *x.shape[2:]), res
     )

--- a/mujoco_torch/_src/constraint.py
+++ b/mujoco_torch/_src/constraint.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 """Core non-smooth constraint functions."""
 
+from typing import NamedTuple
+
 import mujoco
 
 # pylint: enable=g-importing-member
@@ -50,11 +52,10 @@ def _vmap_index(tensor: torch.Tensor, idx: torch.Tensor) -> torch.Tensor:
 # pylint: disable=g-importing-member
 from torch.utils._pytree import tree_map
 
-from mujoco_torch._src.dataclasses import MjTensorClass
 from mujoco_torch._src.types import ConeType, Contact, Data, Model
 
 
-class _Efc(MjTensorClass):
+class _Efc(NamedTuple):
     """Support data for creating constraint matrices."""
 
     J: torch.Tensor
@@ -152,7 +153,6 @@ def _instantiate_equality_connect(m: Model, d: Data, precomp: dict) -> _Efc:
         solref=solref,
         solimp=solimp,
         frictionloss=frictionloss,
-        batch_size=[j.shape[0]],
     )
 
 
@@ -208,7 +208,6 @@ def _instantiate_equality_weld(m: Model, d: Data, precomp: dict) -> _Efc:
         solref=solref,
         solimp=solimp,
         frictionloss=frictionloss,
-        batch_size=[j.shape[0]],
     )
 
 
@@ -247,7 +246,6 @@ def _instantiate_friction(m: Model, d: Data, precomp: dict) -> _Efc:
         solref=solref,
         solimp=solimp,
         frictionloss=frictionloss,
-        batch_size=[size],
     )
 
 
@@ -295,7 +293,6 @@ def _instantiate_equality_joint(m: Model, d: Data, precomp: dict) -> _Efc:
         solref=solref,
         solimp=solimp,
         frictionloss=frictionloss,
-        batch_size=[j.shape[0]],
     )
 
 
@@ -331,7 +328,6 @@ def _instantiate_limit_ball(m: Model, d: Data, precomp: dict) -> _Efc:
         solref=solref,
         solimp=solimp,
         frictionloss=frictionloss,
-        batch_size=[j.shape[0]],
     )
 
 
@@ -368,7 +364,6 @@ def _instantiate_limit_slide_hinge(m: Model, d: Data, precomp: dict) -> _Efc:
         solref=solref,
         solimp=solimp,
         frictionloss=frictionloss,
-        batch_size=[j.shape[0]],
     )
 
 
@@ -401,7 +396,6 @@ def _instantiate_limit_tendon(m: Model, d: Data, precomp: dict) -> _Efc:
         solref=solref,
         solimp=solimp,
         frictionloss=frictionloss,
-        batch_size=[j.shape[0]],
     )
 
 
@@ -447,7 +441,6 @@ def _instantiate_contact_frictionless(m: Model, d: Data) -> _Efc:
         solref=solref,
         solimp=solimp,
         frictionloss=frictionloss,
-        batch_size=[j.shape[0]],
     )
 
 
@@ -512,7 +505,6 @@ def _instantiate_contact_pyramidal(m: Model, d: Data, condim: int, start_idx: in
         solref=solref,
         solimp=solimp,
         frictionloss=frictionloss,
-        batch_size=[j.shape[0]],
     )
 
 
@@ -579,7 +571,6 @@ def _instantiate_contact_elliptic(m: Model, d: Data, condim: int, start_idx: int
         solref=solref,
         solimp=solimp,
         frictionloss=frictionloss,
-        batch_size=[j.shape[0]],
     )
 
 
@@ -677,7 +668,7 @@ def make_constraint(m: Model, d: Data) -> Data:
         padded_nefc = nefc if torch.compiler.is_compiling() else 0
         return _set_constraint_tensors(padded_nefc)
 
-    efc = torch.cat(list(efcs))
+    efc = _Efc(*(torch.cat([getattr(item, field) for item in efcs]) for field in _Efc._fields))
     refsafe = precomp["refsafe"]
 
     @torch.vmap

--- a/mujoco_torch/_src/device.py
+++ b/mujoco_torch/_src/device.py
@@ -144,6 +144,7 @@ _DERIVED = mesh.DERIVED.union(
         (types.Model, "cache_id"),
         # Pre-cached tensor versions of numpy model fields
         (types.Model, "body_rootid_t"),
+        (types.Model, "body_dof_chain_t"),
         (types.Model, "dof_bodyid_t"),
         (types.Model, "dof_Madr_t"),
         (types.Model, "dof_tri_row_t"),
@@ -709,6 +710,21 @@ def _model_derived(value: mujoco.MjModel) -> dict[str, Any]:
     # Pre-cached tensor versions of numpy model fields.
     # These are regular tensors on CPU; .to(device) on the Model moves them.
     result["body_rootid_t"] = torch.as_tensor(np.array(value.body_rootid), dtype=torch.long)
+    body_dof_chains = []
+    for body_id in range(value.nbody):
+        dof_chain = []
+        ancestor_id = body_id
+        while ancestor_id > 0:
+            dof_adr = int(value.body_dofadr[ancestor_id])
+            dof_num = int(value.body_dofnum[ancestor_id])
+            dof_chain.extend(range(dof_adr, dof_adr + dof_num))
+            ancestor_id = int(value.body_parentid[ancestor_id])
+        body_dof_chains.append(dof_chain)
+    max_dof_chain = max((len(chain) for chain in body_dof_chains), default=0)
+    body_dof_chain = np.full((value.nbody, max_dof_chain), -1, dtype=np.int64)
+    for body_id, dof_chain in enumerate(body_dof_chains):
+        body_dof_chain[body_id, : len(dof_chain)] = dof_chain
+    result["body_dof_chain_t"] = torch.as_tensor(body_dof_chain)
     result["dof_bodyid_t"] = torch.as_tensor(np.array(value.dof_bodyid), dtype=torch.long)
     result["dof_Madr_t"] = torch.as_tensor(np.array(value.dof_Madr), dtype=torch.long)
     result["dof_tri_row_t"] = torch.as_tensor(result["dof_tri_row"], dtype=torch.long)

--- a/mujoco_torch/_src/solver.py
+++ b/mujoco_torch/_src/solver.py
@@ -19,6 +19,7 @@ from typing import NamedTuple
 import mujoco
 import torch
 from torch._higher_order_ops.while_loop import while_loop as _torch_while_loop
+from torch._higher_order_ops.while_loop import while_loop_op as _torch_while_loop_op
 
 
 def _inside_functorch() -> bool:
@@ -41,7 +42,7 @@ def while_loop(cond_fn, body_fn, carried_inputs, max_iter=None):
       carried_inputs: initial carry (tuple of tensors / NamedTuples).
       max_iter: unused, kept for backward compatibility.
     """
-    if torch.compiler.is_compiling() or _inside_functorch():
+    if _inside_functorch():
         orig_body_fn = body_fn
 
         def cloning_body(*args):
@@ -51,7 +52,22 @@ def while_loop(cond_fn, body_fn, carried_inputs, max_iter=None):
                 result,
             )
 
-        return _torch_while_loop(cond_fn, cloning_body, carried_inputs)
+        flat_inputs, carried_spec = torch.utils._pytree.tree_flatten(carried_inputs)
+
+        def flat_cond_fn(*flat_args):
+            carried = torch.utils._pytree.tree_unflatten(list(flat_args), carried_spec)
+            return cond_fn(*carried)
+
+        def flat_body_fn(*flat_args):
+            carried = torch.utils._pytree.tree_unflatten(list(flat_args), carried_spec)
+            result = cloning_body(*carried)
+            return tuple(torch.utils._pytree.tree_leaves(result))
+
+        flat_result = _torch_while_loop_op(flat_cond_fn, flat_body_fn, tuple(flat_inputs), tuple())
+        return torch.utils._pytree.tree_unflatten(list(flat_result), carried_spec)
+
+    if torch.compiler.is_compiling():
+        return _torch_while_loop(cond_fn, body_fn, carried_inputs)
 
     val = carried_inputs
     while cond_fn(*val):

--- a/mujoco_torch/_src/support.py
+++ b/mujoco_torch/_src/support.py
@@ -19,7 +19,7 @@ import numpy as np
 import torch
 from torch._C._functorch import _add_batch_dim, _remove_batch_dim, is_batchedtensor, maybe_get_level
 
-from mujoco_torch._src import math, scan
+from mujoco_torch._src import math
 
 # pylint: disable=g-importing-member
 from mujoco_torch._src.types import Data, JacobianType, Model
@@ -137,11 +137,9 @@ def vmap_compatible_index_select(tensor, dim, index):
 
 def jac(m: Model, d: Data, point: torch.Tensor, body_id: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     """Compute pair of (NV, 3) Jacobians of global point attached to body."""
-    fn = lambda carry, b: b if carry is None else b + carry
-    device = point.device if isinstance(point, torch.Tensor) else None
-    mask = (torch.arange(m.nbody, device=device) == body_id) * 1
-    mask = scan.body_tree(m, fn, "b", "b", mask, reverse=True)
-    mask = mask[m.dof_bodyid_t] > 0
+    dof_chain = vmap_compatible_index_select(m.body_dof_chain_t, dim=0, index=body_id)
+    dof_ids = torch.arange(m.dof_bodyid_t.shape[0], device=point.device).unsqueeze(-1)
+    mask = (dof_ids == dof_chain).any(-1)
 
     index = vmap_compatible_index_select(m.body_rootid_t, dim=0, index=body_id).long()
 

--- a/mujoco_torch/_src/types.py
+++ b/mujoco_torch/_src/types.py
@@ -875,6 +875,7 @@ class Model(MjTensorClass):
     cache_id: int
     # Pre-cached tensor versions of numpy model fields (auto-moved by .to())
     body_rootid_t: torch.Tensor
+    body_dof_chain_t: torch.Tensor
     dof_bodyid_t: torch.Tensor
     dof_Madr_t: torch.Tensor
     dof_tri_row_t: torch.Tensor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "mujoco>=3.3",
     "numpy",
     "pyvers>=0.2.2",
-    "tensordict>=0.11",
+    "tensordict>=0.14.0",
     "absl-py",
     "etils",
     "scipy",
@@ -22,12 +22,16 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-zoo = ["torchrl>=0.6"]
+zoo = ["torchrl>=0.14.0"]
 test = ["pytest", "pytest-benchmark"]
 benchmark = ["pytest", "pytest-benchmark", "pytest-xdist"]
 
 [dependency-groups]
 dev = ["ruff"]
+
+[tool.uv.sources]
+tensordict = { git = "https://github.com/pytorch/tensordict.git", branch = "main" }
+torchrl = { git = "https://github.com/pytorch/rl.git", branch = "main" }
 
 [project.urls]
 Homepage = "https://github.com/vmoens/mujoco-torch"

--- a/uv.lock
+++ b/uv.lock
@@ -2,9 +2,13 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
-    "python_full_version < '3.11'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
 ]
 
 [[package]]
@@ -36,27 +40,81 @@ wheels = [
 
 [[package]]
 name = "cuda-bindings"
-version = "12.9.4"
+version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cuda-pathfinder" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/d8/b546104b8da3f562c1ff8ab36d130c8fe1dd6a045ced80b4f6ad74f7d4e1/cuda_bindings-12.9.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d3c842c2a4303b2a580fe955018e31aea30278be19795ae05226235268032e5", size = 12148218, upload-time = "2025-10-21T14:51:28.855Z" },
-    { url = "https://files.pythonhosted.org/packages/45/e7/b47792cc2d01c7e1d37c32402182524774dadd2d26339bd224e0e913832e/cuda_bindings-12.9.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c912a3d9e6b6651853eed8eed96d6800d69c08e94052c292fec3f282c5a817c9", size = 12210593, upload-time = "2025-10-21T14:51:36.574Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/c1/dabe88f52c3e3760d861401bb994df08f672ec893b8f7592dc91626adcf3/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fda147a344e8eaeca0c6ff113d2851ffca8f7dfc0a6c932374ee5c47caa649c8", size = 12151019, upload-time = "2025-10-21T14:51:43.167Z" },
-    { url = "https://files.pythonhosted.org/packages/63/56/e465c31dc9111be3441a9ba7df1941fe98f4aa6e71e8788a3fb4534ce24d/cuda_bindings-12.9.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:32bdc5a76906be4c61eb98f546a6786c5773a881f3b166486449b5d141e4a39f", size = 11906628, upload-time = "2025-10-21T14:51:49.905Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/84/1e6be415e37478070aeeee5884c2022713c1ecc735e6d82d744de0252eee/cuda_bindings-12.9.4-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56e0043c457a99ac473ddc926fe0dc4046694d99caef633e92601ab52cbe17eb", size = 11925991, upload-time = "2025-10-21T14:51:56.535Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/af/6dfd8f2ed90b1d4719bc053ff8940e494640fe4212dc3dd72f383e4992da/cuda_bindings-12.9.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8b72ee72a9cc1b531db31eebaaee5c69a8ec3500e32c6933f2d3b15297b53686", size = 11922703, upload-time = "2025-10-21T14:52:03.585Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/19/90ac264acc00f6df8a49378eedec9fd2db3061bf9263bf9f39fd3d8377c3/cuda_bindings-12.9.4-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d80bffc357df9988dca279734bc9674c3934a654cab10cadeed27ce17d8635ee", size = 11924658, upload-time = "2025-10-21T14:52:10.411Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/8464d133752951c154feafb3b65c297e7d80f301183d220bec4c830f1441/cuda_bindings-13.3.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:120fcc53d57903df529c3486962c56528cba5b7d6c57c99537320ed9922c8b86", size = 6073403, upload-time = "2026-05-29T23:11:36.22Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/1f/5ef51f5fbaa5d4d3201bb3d7555af028ec1aa4416275ccbf73c9e34e3d2d/cuda_bindings-13.3.1-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9851b0caa8bfd3bc6fa054eaf57bea7c8e9c3a62db2d2621224677f49f3c53d0", size = 6675244, upload-time = "2026-05-29T23:11:38.664Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/457ca12dad3ee9bfcc9a545cfd6b64b359ba49de40f776f6e028e678f262/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5879712accf6e14bb01aa5e67440eb84998b8d104b509cc7a6dc0b8f656a474", size = 6053539, upload-time = "2026-05-29T23:11:43.19Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7a/c5e3c34a409b148f5c0f5a4ea374158f95d488862c1dffedf9aa5c639df9/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04436a9364059c84b8f9636f359eccda1cf814341f5b670c71d80d2f79dbc708", size = 6674166, upload-time = "2026-05-29T23:11:45.478Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e32d08f71ebcdf00f0f41eab2eb37e8da94c8ed411cc9f7f7a019ce6b34abe3a", size = 6657965, upload-time = "2026-05-29T23:11:52.227Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c2/ef9b6a63f7dc432712a462c816662e662e00d38caa9b861c8c2588195d03/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2732904099e0a4d4db774a5fc6d91ee95fae065b4d2ecabb4968c5fe2406c9d7", size = 6476660, upload-time = "2026-05-29T23:11:59.188Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/81/bff68ce829999c1e4209c761bbf903b1c06ec570416ddb25020864ad5907/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ab2f74ed65bfef4163ba07a8db16f1085e0729291db12a2423aff84ee8278b8", size = 6013639, upload-time = "2026-05-29T23:12:03.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e0/c8a1f0c8f9ffdea4f5fe6dbab89b326cef4d85caf489dad39e209da89416/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd4c814d311ec08c981f6dded1dbe7d4b371067ee4f6c14cccec4bde9590f80", size = 6534419, upload-time = "2026-05-29T23:12:05.633Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b8/83b1f563925b290f2d11a01a77a84013ba56052fe3653a5bef3ccfbb43d6/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3c772dfff49681541d59630c90f858e173ac926b9c593a2b7123f2a1043cc76", size = 5809771, upload-time = "2026-05-29T23:12:10.422Z" },
+    { url = "https://files.pythonhosted.org/packages/12/20/e79b4bfe98f075195afb6343d41c498f9dbd2d161d7021d4d28bceb83581/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:36febb7c1079d68a981dbbd8d5a67235b399802b82075c9388624719607e52b9", size = 6358584, upload-time = "2026-05-29T23:12:12.767Z" },
 ]
 
 [[package]]
 name = "cuda-pathfinder"
-version = "1.4.0"
+version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/60/d8f1dbfb7f06b94c662e98c95189e6f39b817da638bc8fcea0d003f89e5d/cuda_pathfinder-1.4.0-py3-none-any.whl", hash = "sha256:437079ca59e7b61ae439ecc501d69ed87b3accc34d58153ef1e54815e2c2e118", size = 38406, upload-time = "2026-02-25T22:13:00.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/b1/ef21259ec74fe0b265ed201379de1d0ef7c14178313ee03705952f1b7093/cuda_pathfinder-1.8.0-py3-none-any.whl", hash = "sha256:c44e574dc997fae2814721d1ae97d0fd6db76db82decbe9b753bf75de53f515e", size = 62539, upload-time = "2026-08-27T21:33:03.229Z" },
+]
+
+[[package]]
+name = "cuda-toolkit"
+version = "13.0.3.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/c7/a79086a62c98befcdb8349656c6f114e2db3b8b2422f6e25c97a7f2a9a3c/cuda_toolkit-13.0.3.0-py2.py3-none-any.whl", hash = "sha256:d693caaa261214ddd7dbb60d68e71cbed884e68c2be7509778f3051da0b91c3f", size = 2512, upload-time = "2026-04-14T00:50:08.173Z" },
+]
+
+[package.optional-dependencies]
+cublas = [
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cudart = [
+    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cufft = [
+    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cufile = [
+    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cupti = [
+    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+curand = [
+    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cusolver = [
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cusparse = [
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+nvjitlink = [
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+nvrtc = [
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+nvtx = [
+    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 
 [[package]]
@@ -81,7 +139,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -145,6 +203,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/93/977b9e679e356871d428ae7a1139ec767dd5177bed58a6344b4d2199e00f/glfw-2.10.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:cca5158d62189e08792b1ae54f92307a282921a0e7783315b467e21b0a381c88", size = 243480, upload-time = "2026-03-10T17:21:30.538Z" },
     { url = "https://files.pythonhosted.org/packages/f9/bd/cea9569c8f2188b0a104472951420434a3e1f5cf26f5836ef9d7227a1a30/glfw-2.10.0-py2.py3-none-win32.whl", hash = "sha256:5e024509989740e8e7b86cc4aab508195495f79879072b0e1f68bd036a2916ad", size = 552641, upload-time = "2026-03-10T17:21:32.653Z" },
     { url = "https://files.pythonhosted.org/packages/cc/9b/4366ad3e1c0688146c70aa6143584d6a8d88583b9390f106250e25a3d5cd/glfw-2.10.0-py2.py3-none-win_amd64.whl", hash = "sha256:7f787ee8645781f10e8800438ce4357ab38c573ffb191aba380c1e72eba6311c", size = 559423, upload-time = "2026-03-10T17:21:34.766Z" },
+]
+
+[[package]]
+name = "hoptorch"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyvers" },
+    { name = "torch", version = "2.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' or sys_platform != 'darwin'" },
+    { name = "torch", version = "2.15.0.dev20260830", source = { registry = "https://download.pytorch.org/whl/nightly/cpu" }, marker = "python_full_version != '3.12.*' and sys_platform == 'darwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/e4/6b4a08168cd3c9dd804df68131e1dcd7ea9507ad78d548f63d3979a34e5c/hoptorch-0.1.4.tar.gz", hash = "sha256:958e22455460342f195c63f989543da6fcc66337b2f8fca1980454209d36d450", size = 15745, upload-time = "2026-06-05T10:02:12.697Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/43/c038f118b0ce03385de7dcabfa64281e3387681f64668b1ee44f6b555cac/hoptorch-0.1.4-py3-none-any.whl", hash = "sha256:fc0b49e5a8b2370db8b47185fedaf91b3c6cf7f6e726079bb02aca6dbf8bb04f", size = 12527, upload-time = "2026-06-05T10:02:11.673Z" },
 ]
 
 [[package]]
@@ -333,7 +405,8 @@ dependencies = [
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tensordict" },
-    { name = "torch" },
+    { name = "torch", version = "2.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' or sys_platform != 'darwin'" },
+    { name = "torch", version = "2.15.0.dev20260830", source = { registry = "https://download.pytorch.org/whl/nightly/cpu" }, marker = "python_full_version != '3.12.*' and sys_platform == 'darwin'" },
     { name = "trimesh" },
 ]
 
@@ -369,9 +442,9 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'benchmark'" },
     { name = "pyvers", specifier = ">=0.2.2" },
     { name = "scipy" },
-    { name = "tensordict", specifier = ">=0.11" },
+    { name = "tensordict", git = "https://github.com/pytorch/tensordict.git?branch=main" },
     { name = "torch", specifier = ">=2.1" },
-    { name = "torchrl", marker = "extra == 'zoo'", specifier = ">=0.6" },
+    { name = "torchrl", marker = "extra == 'zoo'", git = "https://github.com/pytorch/rl.git?branch=main" },
     { name = "trimesh" },
 ]
 provides-extras = ["zoo", "test", "benchmark"]
@@ -384,7 +457,8 @@ name = "networkx"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
 wheels = [
@@ -396,8 +470,11 @@ name = "networkx"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
@@ -409,7 +486,8 @@ name = "numpy"
 version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
 wheels = [
@@ -474,8 +552,11 @@ name = "numpy"
 version = "2.4.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/57/fd/0005efbd0af48e55eb3c7208af93f2862d4b1a56cd78e84309a2d959208d/numpy-2.4.2.tar.gz", hash = "sha256:659a6107e31a83c4e33f763942275fd278b21d095094044eb35569e86a21ddae", size = 20723651, upload-time = "2026-01-31T23:13:10.135Z" }
 wheels = [
@@ -553,137 +634,155 @@ wheels = [
 ]
 
 [[package]]
-name = "nvidia-cublas-cu12"
-version = "12.8.4.1"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142", size = 594346921, upload-time = "2025-03-07T01:44:31.254Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-cupti-cu12"
-version = "12.8.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621, upload-time = "2025-03-07T01:40:21.213Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-nvrtc-cu12"
-version = "12.8.93"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994", size = 88040029, upload-time = "2025-03-07T01:42:13.562Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-runtime-cu12"
-version = "12.8.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765, upload-time = "2025-03-07T01:40:01.615Z" },
-]
-
-[[package]]
-name = "nvidia-cudnn-cu12"
-version = "9.10.2.21"
+name = "nvidia-cublas"
+version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/cd/154ca20c38269e05eff77c1464e6c1da89f50a6390b565e9d82e06bc11e1/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:37936a16db8fe4ac1f065c2139360608a543a09275cb1a1af612e08cfa065436", size = 423138758, upload-time = "2026-04-08T18:46:58.655Z" },
 ]
 
 [[package]]
-name = "nvidia-cufft-cu12"
-version = "11.3.3.83"
+name = "nvidia-cuda-cupti"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime"
+version = "13.0.96"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu13"
+version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
+    { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304", size = 366173588, upload-time = "2026-03-09T19:29:34.474Z" },
 ]
 
 [[package]]
-name = "nvidia-cufile-cu12"
-version = "1.13.1.3"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc", size = 1197834, upload-time = "2025-03-07T01:45:50.723Z" },
-]
-
-[[package]]
-name = "nvidia-curand-cu12"
-version = "10.3.9.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/aa/6584b56dc84ebe9cf93226a5cde4d99080c8e90ab40f0c27bda7a0f29aa1/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9", size = 63619976, upload-time = "2025-03-07T01:46:23.323Z" },
-]
-
-[[package]]
-name = "nvidia-cusolver-cu12"
-version = "11.7.3.90"
+name = "nvidia-cufft"
+version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
 ]
 
 [[package]]
-name = "nvidia-cusparse-cu12"
-version = "12.5.8.93"
+name = "nvidia-cufile"
+version = "1.15.1.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/70/4f193de89a48b71714e74602ee14d04e4019ad36a5a9f20c425776e72cd6/nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44", size = 1223672, upload-time = "2025-09-04T08:32:22.779Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/73/cc4a14c9813a8a0d509417cf5f4bdaba76e924d58beb9864f5a7baceefbf/nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1", size = 1136992, upload-time = "2025-09-04T08:32:14.119Z" },
+]
+
+[[package]]
+name = "nvidia-curand"
+version = "10.4.0.35"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver"
+version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
 ]
 
 [[package]]
-name = "nvidia-cusparselt-cu12"
-version = "0.7.1"
+name = "nvidia-cusparse"
+version = "12.6.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu13"
+version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623", size = 287193691, upload-time = "2025-02-26T00:15:44.104Z" },
+    { url = "https://files.pythonhosted.org/packages/46/e1/cdc1797eadf82d3a9a575a19b33fdc871a97edbec42c00b5b5e914f4aff4/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f", size = 221051344, upload-time = "2025-09-05T18:49:51.289Z" },
+    { url = "https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0", size = 170148586, upload-time = "2025-09-05T18:50:50.248Z" },
 ]
 
 [[package]]
-name = "nvidia-nccl-cu12"
-version = "2.27.5"
+name = "nvidia-nccl-cu13"
+version = "2.29.7"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/89/f7a07dc961b60645dbbf42e80f2bc85ade7feb9a491b11a1e973aa00071f/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ad730cf15cb5d25fe849c6e6ca9eb5b76db16a80f13f425ac68d8e2e55624457", size = 322348229, upload-time = "2025-06-26T04:11:28.385Z" },
+    { url = "https://files.pythonhosted.org/packages/72/0d/daf50d44177ee0cbc7ff0a0c91eb5ff676c82be42f9a970bc7597f440c3a/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:674a12383e3c38a1bcccae7d4f3633b37852230b6047883cb2f4c2d1b36d9bf5", size = 206014712, upload-time = "2026-03-03T05:34:20.843Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f4/58e4e91b6919367c7aafb8e36fce9aad1a3047e536bf7e2fd560927d3a4c/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:edd81538446786ec3b73972543e53bb43bcaf0bfc8ef76cb679fcc390ffe136d", size = 205976000, upload-time = "2026-03-03T05:36:24.472Z" },
 ]
 
 [[package]]
-name = "nvidia-nvjitlink-cu12"
-version = "12.8.93"
+name = "nvidia-nvjitlink"
+version = "13.3.33"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836, upload-time = "2025-03-07T01:49:55.661Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/580ca6f29dcab0221db8706badca1bbbb084f1975c4d4e83329c3a7e31f0/nvidia_nvjitlink-13.3.33-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:26a6de7fb4c8fdaa7703d3dad720d6d427ddfea5c48a528fd97c11733ad830e5", size = 40742423, upload-time = "2026-05-26T16:54:51.613Z" },
+    { url = "https://files.pythonhosted.org/packages/69/30/45414e35ff2eee7db3da037e5707037ccf9d2b5218ffbdb055ea4d5aa98a/nvidia_nvjitlink-13.3.33-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ce48b37dfeb3cb1eae4cf85adacb47d7a6539ea2272870c9a3628ce275c2037e", size = 39168635, upload-time = "2026-05-26T16:54:13.906Z" },
 ]
 
 [[package]]
-name = "nvidia-nvshmem-cu12"
+name = "nvidia-nvshmem-cu13"
 version = "3.4.5"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/09/6ea3ea725f82e1e76684f0708bbedd871fc96da89945adeba65c3835a64c/nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:042f2500f24c021db8a06c5eec2539027d57460e1c1a762055a6554f72c369bd", size = 139103095, upload-time = "2025-09-06T00:32:31.266Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/0f/05cc9c720236dcd2db9c1ab97fff629e96821be2e63103569da0c9b72f19/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dc2a197f38e5d0376ad52cd1a2a3617d3cdc150fd5966f4aee9bcebb1d68fe9", size = 60215947, upload-time = "2025-09-06T00:32:20.022Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/a9bf80a609e74e3b000fef598933235c908fcefcef9026042b8e6dfde2a9/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80", size = 60412546, upload-time = "2025-09-06T00:32:41.564Z" },
 ]
 
 [[package]]
-name = "nvidia-nvtx-cu12"
-version = "12.8.90"
+name = "nvidia-nvtx"
+version = "13.0.85"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
 ]
 
 [[package]]
@@ -858,11 +957,11 @@ wheels = [
 
 [[package]]
 name = "pyvers"
-version = "0.2.2"
+version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/32/99/23c73a1298b1c642d8ebdd78e1db4daf1e474152e6839df4f5c93357a3db/pyvers-0.2.2.tar.gz", hash = "sha256:205026bcd0b4c09198cb3a32f243fd179ef012882ce16d93dcb755320acd56f7", size = 12104, upload-time = "2026-01-23T14:12:07.619Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/21/9daf8da2793d112a04b46ac33ab9046c91b0af8292cd93b3cfdd07ff7169/pyvers-0.2.3.tar.gz", hash = "sha256:c4b81c3a033963245e124cdecb052783c9c4cea3bb08c051833af1c44faa6283", size = 12347, upload-time = "2026-07-09T13:58:07.046Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/bf/ea840f706b7824dd57220484465995309c8c217995ddb7ce4b262240e912/pyvers-0.2.2-py3-none-any.whl", hash = "sha256:c4696408a0b15fbaa90df33d3bc579cf23a74a73541858f5470216f12f51f3b1", size = 11569, upload-time = "2026-01-23T14:12:06.246Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/8d/63787e8feda59d981ebc953b6581ccab3c97cf7bfe0a6a407c07b50fc86c/pyvers-0.2.3-py3-none-any.whl", hash = "sha256:6f5b5612f2f4bd08caa49baa70fc5f875fc7da701a5385c13e244eea6b8114dd", size = 11757, upload-time = "2026-07-09T13:58:06.078Z" },
 ]
 
 [[package]]
@@ -895,10 +994,11 @@ name = "scipy"
 version = "1.15.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -954,11 +1054,14 @@ name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -1047,8 +1150,8 @@ wheels = [
 
 [[package]]
 name = "tensordict"
-version = "0.11.0"
-source = { registry = "https://pypi.org/simple" }
+version = "0.14.0+g9777798"
+source = { git = "https://github.com/pytorch/tensordict#9777798228a19ff9e50ef794cd53a439db68c5ad" }
 dependencies = [
     { name = "cloudpickle" },
     { name = "importlib-metadata" },
@@ -1057,37 +1160,8 @@ dependencies = [
     { name = "orjson", marker = "python_full_version < '3.13'" },
     { name = "packaging" },
     { name = "pyvers" },
-    { name = "torch" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/bc/2411956883bf1c7531e107dd79225ca47ce4a42d9306da015f625a6f08c5/tensordict-0.11.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:269a94f6afd8229718f8a657bf093f2c861dd24223625fdadfed446cf4cdf86e", size = 813584, upload-time = "2026-01-26T11:35:55.172Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/0b/c2d98efc3491bb5c6600640bb9a49187896b982dfb4950973ff066d1ffb1/tensordict-0.11.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:10c3617d1f9427e0a3ca0571190ef4a0d39f5cd3d35e84c290326691e0954de3", size = 458449, upload-time = "2026-01-26T11:35:56.549Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/1f/72fc06c9f52174ca05499ecc6d8fe27e94e63b95728373c459fe35bd4970/tensordict-0.11.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:05b5ed6ac3282b84c07b65a7a131450928408ef6a3b0b9b950415e9cdd1a5d4c", size = 461677, upload-time = "2026-01-26T11:35:58.322Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/fe/2792fb8a4013ab5318e2207aadd24919097ab6adda9eb52db43b5e84be29/tensordict-0.11.0-cp310-cp310-win_amd64.whl", hash = "sha256:102e4c389b57baff68824075b1b6c4477a2b8cec7d80a25da2780af175995c15", size = 506657, upload-time = "2026-01-26T11:35:59.438Z" },
-    { url = "https://files.pythonhosted.org/packages/54/81/76855a0371bd3b4b9e372685b1659d4310d64626b3bf9d5fd190937a5b3d/tensordict-0.11.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:872d907ba67a820b063b839a3830d580a803db05f7b6b4012d1a237b80156597", size = 815365, upload-time = "2026-01-26T11:36:00.999Z" },
-    { url = "https://files.pythonhosted.org/packages/43/87/bcc10f8ed12112e58597da74826c22133aa39d3c4668f225b5c430fbf467/tensordict-0.11.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:9e359a2b107f375a9226dc2c71c891c3fdc48bb5f30e11c052655794e860e6ce", size = 460058, upload-time = "2026-01-26T11:36:02.455Z" },
-    { url = "https://files.pythonhosted.org/packages/70/85/a850ce6d61cca041baeaad6e3ae85d80f848b1559ef9102304a60fa7c3e0/tensordict-0.11.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:612d0fc1340bb42b9c207fa788dac950716470a7a9031f8b09fa9d4551cd1ab9", size = 463186, upload-time = "2026-01-26T11:36:04.129Z" },
-    { url = "https://files.pythonhosted.org/packages/37/00/2d5f488bcfb5c86c795a07f76a6a84dc724ff4e4489e5db1f44513fa7ddc/tensordict-0.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:2cdf014575e3961c54c156a7b01e50da55e59472ebc74246b55b447887c92d41", size = 509219, upload-time = "2026-01-26T11:36:05.8Z" },
-    { url = "https://files.pythonhosted.org/packages/46/7c/6b47df6f8749e873d5bcd3260a78a8c5de0d92fff4aaf2739de29c6e7089/tensordict-0.11.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:683840259eb7d29836751bff48249c2ee36b7f1ccff50dcaed843d96915d768a", size = 815976, upload-time = "2026-01-26T11:36:07.452Z" },
-    { url = "https://files.pythonhosted.org/packages/19/b5/af7e9e8f3540cc2e6123b035fe0b1541c0514fadeb31862e14a6bb424ebc/tensordict-0.11.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:8125611fa8187a49840c1e07480644749a2bdf8520a882de68dfffac79b73a61", size = 461002, upload-time = "2026-01-26T11:36:09.224Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/48/9363e462522eef0117c852a30c4f09ea86bd2c81b8792118ae5d63289729/tensordict-0.11.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7236c533d9076e8368952849c7bb9bf76a012324e22a133acd617ff8283fe59f", size = 465538, upload-time = "2026-01-26T11:36:10.866Z" },
-    { url = "https://files.pythonhosted.org/packages/76/fc/659137f50d77fe868614963f322bfb47a1cd7ff685b3a34f00ffcd78d04f/tensordict-0.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:d62f24c4dbf5e0eed1231beeb482e5b183d2fcb9c9e199828506f5eec5ad8a86", size = 510247, upload-time = "2026-01-26T11:36:12.118Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/8d/64b04f4c3ae77cd1330f697950b8ac9785f815be152805b126321f4c9483/tensordict-0.11.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:fa1f77fc63b37c19fe8e3e684d7d9dcd0e7d39beaa1d4dd09e6369aab4f47036", size = 815987, upload-time = "2026-01-26T11:36:13.277Z" },
-    { url = "https://files.pythonhosted.org/packages/53/6f/4ef78fdd6d0d33c1cbc9b13e7f3079bf46f1c9e53a728e986c6f664be774/tensordict-0.11.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:526a1391f4a13ec82b781078a9190fc0626bfdeedaf30a32ba84264db76fd5fb", size = 460959, upload-time = "2026-01-26T11:36:14.439Z" },
-    { url = "https://files.pythonhosted.org/packages/96/62/6322a759fc4b62c2ded50b3330bcb1e541d86734b86603d3e4c4c1442b16/tensordict-0.11.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:525bff4b95539b63fdb45e82c166c7481d039df604007baab69fbcfcb1310ac4", size = 465438, upload-time = "2026-01-26T11:36:15.971Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/d1/2d00adaa35a0a37f9c796709a739904ab1c032f721dcef736eb8bd72a999/tensordict-0.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:5a63f53f20aa90ea23cac69ca4daf8db97d12dd0c1b51b855424bc48e411914c", size = 510202, upload-time = "2026-01-26T11:36:17.196Z" },
-    { url = "https://files.pythonhosted.org/packages/26/20/014904cd5e5b851ea7b1c9a46b91a5c3a850fc6807b640d7a9a09c8714aa/tensordict-0.11.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:0c925186aabb04aaa080a1b0160f48dad0911d3dc42bfb5dabdc9ed60518fbd7", size = 822881, upload-time = "2026-01-26T11:36:18.381Z" },
-    { url = "https://files.pythonhosted.org/packages/60/85/4e54d398a53520f624d291f8a498d389fbbdf740d3a6b018d67c50feef55/tensordict-0.11.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:c6b3d465f72ddc8fac2b1f031f873f38d073dcca897d1c8751fa4e95142d848f", size = 462403, upload-time = "2026-01-26T11:36:19.506Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/ec/bfc5384cea17fecca6980ee9e6fe5b75e55bab09bfe1975795107d8491ff/tensordict-0.11.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:06a0df47c227c81ce6a3d7a7960a0ca2a9ab832a3460e9a4a88a3c5b929903e4", size = 465141, upload-time = "2026-01-26T11:36:20.658Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/d8/b84caf450e1cce55f9b3cd64c3f9d56b3d0cd9265ea728500605fd71a971/tensordict-0.11.0-cp313-cp313t-win_amd64.whl", hash = "sha256:e963e114e8c03d9b2a93b41899af6598a27db1c5fa17c78aeb0cc16ab9e143c5", size = 520028, upload-time = "2026-01-26T11:36:21.904Z" },
-    { url = "https://files.pythonhosted.org/packages/22/eb/a30a548306ddb90010bb8440d463ebff1b3a1a6682e7cf8b47a3a9d6b8a2/tensordict-0.11.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:b90bfef3d83e36771b2bb3d888abc2102a09eb0cb43d24141396272ce1cb76dd", size = 818890, upload-time = "2026-01-26T11:36:23.053Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/44/48f8ece93bdd6009e8b02f88db818c9a2ca14064c339adeaf7f42f0551f4/tensordict-0.11.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:70bd7e583fb9fb7ee28dd7a783170411dde5f47191cefa87063cff414357ad24", size = 461355, upload-time = "2026-01-26T11:36:24.418Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/31/37c668e4477db51322f73289a3b3b45eba1ff5d0fb593f7cb258553a382e/tensordict-0.11.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:27169933ad38f549b6317a4bd9a6cee92a72cb2e9d5f5f909d42a3fc81111105", size = 465724, upload-time = "2026-01-26T11:36:25.737Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/61/3e219bac522cf8a33fe41fdf45682fbccf660ba3426e7a80d787277f4bc7/tensordict-0.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:f2effe50ce519d2bebb4e2cfddef7e1faf265524e8ada3177ca4f7f6e91098d7", size = 510486, upload-time = "2026-01-26T11:36:26.826Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/25/addc886b14cf16469ef40cb1647f8f36ab3fb993e9b3053c056a105dcc55/tensordict-0.11.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:805c416e4771aea3fa4cca074c4b0db06816098f5fa2bbde3682e06a438106a1", size = 822879, upload-time = "2026-01-26T11:36:28.343Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/e7/a1af12078d33d2f834fb3b4a52a17808e91c0be1439ef111a4858b1a2881/tensordict-0.11.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c669e18fad8966125d900e5591af59f8da1177618db9d22cab246e0b393c7d2d", size = 462405, upload-time = "2026-01-26T11:36:30.094Z" },
-    { url = "https://files.pythonhosted.org/packages/55/be/88f8a8aa1056fbf8ec17af5e9e31cf25e3c60f04943bcb8af89cb2d44528/tensordict-0.11.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:da98ecbd706b630c77911595abb45829eb8d9006c50751dff506179a132517bd", size = 465139, upload-time = "2026-01-26T11:36:31.271Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/1e/b556a5b4dc88ff3f63e744f6487b9f84e4a149a4a5f2a6628f472dd2d4d3/tensordict-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:3b5f95b726405e2da308bdb2e81523d1f4b8e85baf88856620500af689d41064", size = 520145, upload-time = "2026-01-26T11:36:32.423Z" },
+    { name = "torch", version = "2.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' or sys_platform != 'darwin'" },
+    { name = "torch", version = "2.15.0.dev20260830", source = { registry = "https://download.pytorch.org/whl/nightly/cpu" }, marker = "python_full_version != '3.12.*' and sys_platform == 'darwin'" },
 ]
 
 [[package]]
@@ -1146,119 +1220,102 @@ wheels = [
 
 [[package]]
 name = "torch"
-version = "2.10.0"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+]
 dependencies = [
-    { name = "cuda-bindings", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "cuda-bindings", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "jinja2" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "setuptools", marker = "python_full_version >= '3.12'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform != 'darwin'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or sys_platform == 'darwin'" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "setuptools" },
     { name = "sympy" },
-    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "triton", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/30/bfebdd8ec77db9a79775121789992d6b3b75ee5494971294d7b4b7c999bc/torch-2.10.0-2-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:2b980edd8d7c0a68c4e951ee1856334a43193f98730d97408fbd148c1a933313", size = 79411457, upload-time = "2026-02-10T21:44:59.189Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/8b/4b61d6e13f7108f36910df9ab4b58fd389cc2520d54d81b88660804aad99/torch-2.10.0-2-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:418997cb02d0a0f1497cf6a09f63166f9f5df9f3e16c8a716ab76a72127c714f", size = 79423467, upload-time = "2026-02-10T21:44:48.711Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
-    { url = "https://files.pythonhosted.org/packages/16/ee/efbd56687be60ef9af0c9c0ebe106964c07400eade5b0af8902a1d8cd58c/torch-2.10.0-3-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a1ff626b884f8c4e897c4c33782bdacdff842a165fee79817b1dd549fdda1321", size = 915510070, upload-time = "2026-03-11T14:16:39.386Z" },
-    { url = "https://files.pythonhosted.org/packages/36/ab/7b562f1808d3f65414cd80a4f7d4bb00979d9355616c034c171249e1a303/torch-2.10.0-3-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:ac5bdcbb074384c66fa160c15b1ead77839e3fe7ed117d667249afce0acabfac", size = 915518691, upload-time = "2026-03-11T14:15:43.147Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/7a/abada41517ce0011775f0f4eacc79659bc9bc6c361e6bfe6f7052a6b9363/torch-2.10.0-3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:98c01b8bb5e3240426dcde1446eed6f40c778091c8544767ef1168fc663a05a6", size = 915622781, upload-time = "2026-03-11T14:17:11.354Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/c6/4dfe238342ffdcec5aef1c96c457548762d33c40b45a1ab7033bb26d2ff2/torch-2.10.0-3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:80b1b5bfe38eb0e9f5ff09f206dcac0a87aadd084230d4a36eea5ec5232c115b", size = 915627275, upload-time = "2026-03-11T14:16:11.325Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/f0/72bf18847f58f877a6a8acf60614b14935e2f156d942483af1ffc081aea0/torch-2.10.0-3-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:46b3574d93a2a8134b3f5475cfb98e2eb46771794c57015f6ad1fb795ec25e49", size = 915523474, upload-time = "2026-03-11T14:17:44.422Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/39/590742415c3030551944edc2ddc273ea1fdfe8ffb2780992e824f1ebee98/torch-2.10.0-3-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:b1d5e2aba4eb7f8e87fbe04f86442887f9167a35f092afe4c237dfcaaef6e328", size = 915632474, upload-time = "2026-03-11T14:15:13.666Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/8e/34949484f764dde5b222b7fe3fede43e4a6f0da9d7f8c370bb617d629ee2/torch-2.10.0-3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:0228d20b06701c05a8f978357f657817a4a63984b0c90745def81c18aedfa591", size = 915523882, upload-time = "2026-03-11T14:14:46.311Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/1a/c61f36cfd446170ec27b3a4984f072fd06dab6b5d7ce27e11adb35d6c838/torch-2.10.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:5276fa790a666ee8becaffff8acb711922252521b28fbce5db7db5cf9cb2026d", size = 145992962, upload-time = "2026-01-21T16:24:14.04Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/60/6662535354191e2d1555296045b63e4279e5a9dbad49acf55a5d38655a39/torch-2.10.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:aaf663927bcd490ae971469a624c322202a2a1e68936eb952535ca4cd3b90444", size = 915599237, upload-time = "2026-01-21T16:23:25.497Z" },
-    { url = "https://files.pythonhosted.org/packages/40/b8/66bbe96f0d79be2b5c697b2e0b187ed792a15c6c4b8904613454651db848/torch-2.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:a4be6a2a190b32ff5c8002a0977a25ea60e64f7ba46b1be37093c141d9c49aeb", size = 113720931, upload-time = "2026-01-21T16:24:23.743Z" },
-    { url = "https://files.pythonhosted.org/packages/76/bb/d820f90e69cda6c8169b32a0c6a3ab7b17bf7990b8f2c680077c24a3c14c/torch-2.10.0-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:35e407430795c8d3edb07a1d711c41cc1f9eaddc8b2f1cc0a165a6767a8fb73d", size = 79411450, upload-time = "2026-01-21T16:25:30.692Z" },
-    { url = "https://files.pythonhosted.org/packages/78/89/f5554b13ebd71e05c0b002f95148033e730d3f7067f67423026cc9c69410/torch-2.10.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:3282d9febd1e4e476630a099692b44fdc214ee9bf8ee5377732d9d9dfe5712e4", size = 145992610, upload-time = "2026-01-21T16:25:26.327Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/30/a3a2120621bf9c17779b169fc17e3dc29b230c29d0f8222f499f5e159aa8/torch-2.10.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:a2f9edd8dbc99f62bc4dfb78af7bf89499bca3d753423ac1b4e06592e467b763", size = 915607863, upload-time = "2026-01-21T16:25:06.696Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/3d/c87b33c5f260a2a8ad68da7147e105f05868c281c63d65ed85aa4da98c66/torch-2.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:29b7009dba4b7a1c960260fc8ac85022c784250af43af9fb0ebafc9883782ebd", size = 113723116, upload-time = "2026-01-21T16:25:21.916Z" },
-    { url = "https://files.pythonhosted.org/packages/61/d8/15b9d9d3a6b0c01b883787bd056acbe5cc321090d4b216d3ea89a8fcfdf3/torch-2.10.0-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:b7bd80f3477b830dd166c707c5b0b82a898e7b16f59a7d9d42778dd058272e8b", size = 79423461, upload-time = "2026-01-21T16:24:50.266Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/af/758e242e9102e9988969b5e621d41f36b8f258bb4a099109b7a4b4b50ea4/torch-2.10.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5fd4117d89ffd47e3dcc71e71a22efac24828ad781c7e46aaaf56bf7f2796acf", size = 145996088, upload-time = "2026-01-21T16:24:44.171Z" },
-    { url = "https://files.pythonhosted.org/packages/23/8e/3c74db5e53bff7ed9e34c8123e6a8bfef718b2450c35eefab85bb4a7e270/torch-2.10.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:787124e7db3b379d4f1ed54dd12ae7c741c16a4d29b49c0226a89bea50923ffb", size = 915711952, upload-time = "2026-01-21T16:23:53.503Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/01/624c4324ca01f66ae4c7cd1b74eb16fb52596dce66dbe51eff95ef9e7a4c/torch-2.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:2c66c61f44c5f903046cc696d088e21062644cbe541c7f1c4eaae88b2ad23547", size = 113757972, upload-time = "2026-01-21T16:24:39.516Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/5c/dee910b87c4d5c0fcb41b50839ae04df87c1cfc663cf1b5fca7ea565eeaa/torch-2.10.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:6d3707a61863d1c4d6ebba7be4ca320f42b869ee657e9b2c21c736bf17000294", size = 79498198, upload-time = "2026-01-21T16:24:34.704Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/6f/f2e91e34e3fcba2e3fc8d8f74e7d6c22e74e480bbd1db7bc8900fdf3e95c/torch-2.10.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:5c4d217b14741e40776dd7074d9006fd28b8a97ef5654db959d8635b2fe5f29b", size = 146004247, upload-time = "2026-01-21T16:24:29.335Z" },
-    { url = "https://files.pythonhosted.org/packages/98/fb/5160261aeb5e1ee12ee95fe599d0541f7c976c3701d607d8fc29e623229f/torch-2.10.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6b71486353fce0f9714ca0c9ef1c850a2ae766b409808acd58e9678a3edb7738", size = 915716445, upload-time = "2026-01-21T16:22:45.353Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/16/502fb1b41e6d868e8deb5b0e3ae926bbb36dab8ceb0d1b769b266ad7b0c3/torch-2.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:c2ee399c644dc92ef7bc0d4f7e74b5360c37cdbe7c5ba11318dda49ffac2bc57", size = 113757050, upload-time = "2026-01-21T16:24:19.204Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/0b/39929b148f4824bc3ad6f9f72a29d4ad865bcf7ebfc2fa67584773e083d2/torch-2.10.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:3202429f58309b9fa96a614885eace4b7995729f44beb54d3e4a47773649d382", size = 79851305, upload-time = "2026-01-21T16:24:09.209Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/14/21fbce63bc452381ba5f74a2c0a959fdf5ad5803ccc0c654e752e0dbe91a/torch-2.10.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:aae1b29cd68e50a9397f5ee897b9c24742e9e306f88a807a27d617f07adb3bd8", size = 146005472, upload-time = "2026-01-21T16:22:29.022Z" },
-    { url = "https://files.pythonhosted.org/packages/54/fd/b207d1c525cb570ef47f3e9f836b154685011fce11a2f444ba8a4084d042/torch-2.10.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:6021db85958db2f07ec94e1bc77212721ba4920c12a18dc552d2ae36a3eb163f", size = 915612644, upload-time = "2026-01-21T16:21:47.019Z" },
-    { url = "https://files.pythonhosted.org/packages/36/53/0197f868c75f1050b199fe58f9bf3bf3aecac9b4e85cc9c964383d745403/torch-2.10.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ff43db38af76fda183156153983c9a096fc4c78d0cd1e07b14a2314c7f01c2c8", size = 113997015, upload-time = "2026-01-21T16:23:00.767Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/13/e76b4d9c160e89fff48bf16b449ea324bda84745d2ab30294c37c2434c0d/torch-2.10.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:cdf2a523d699b70d613243211ecaac14fe9c5df8a0b0a9c02add60fb2a413e0f", size = 79498248, upload-time = "2026-01-21T16:23:09.315Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/93/716b5ac0155f1be70ed81bacc21269c3ece8dba0c249b9994094110bfc51/torch-2.10.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:bf0d9ff448b0218e0433aeb198805192346c4fd659c852370d5cc245f602a06a", size = 79464992, upload-time = "2026-01-21T16:23:05.162Z" },
-    { url = "https://files.pythonhosted.org/packages/69/2b/51e663ff190c9d16d4a8271203b71bc73a16aa7619b9f271a69b9d4a936b/torch-2.10.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:233aed0659a2503b831d8a67e9da66a62c996204c0bba4f4c442ccc0c68a3f60", size = 146018567, upload-time = "2026-01-21T16:22:23.393Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/cd/4b95ef7f293b927c283db0b136c42be91c8ec6845c44de0238c8c23bdc80/torch-2.10.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:682497e16bdfa6efeec8cde66531bc8d1fbbbb4d8788ec6173c089ed3cc2bfe5", size = 915721646, upload-time = "2026-01-21T16:21:16.983Z" },
-    { url = "https://files.pythonhosted.org/packages/56/97/078a007208f8056d88ae43198833469e61a0a355abc0b070edd2c085eb9a/torch-2.10.0-cp314-cp314-win_amd64.whl", hash = "sha256:6528f13d2a8593a1a412ea07a99812495bec07e9224c28b2a25c0a30c7da025c", size = 113752373, upload-time = "2026-01-21T16:22:13.471Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/94/71994e7d0d5238393df9732fdab607e37e2b56d26a746cb59fdb415f8966/torch-2.10.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f5ab4ba32383061be0fb74bda772d470140a12c1c3b58a0cfbf3dae94d164c28", size = 79850324, upload-time = "2026-01-21T16:22:09.494Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/65/1a05346b418ea8ccd10360eef4b3e0ce688fba544e76edec26913a8d0ee0/torch-2.10.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:716b01a176c2a5659c98f6b01bf868244abdd896526f1c692712ab36dbaf9b63", size = 146006482, upload-time = "2026-01-21T16:22:18.42Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/b9/5f6f9d9e859fc3235f60578fa64f52c9c6e9b4327f0fe0defb6de5c0de31/torch-2.10.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:d8f5912ba938233f86361e891789595ff35ca4b4e2ac8fe3670895e5976731d6", size = 915613050, upload-time = "2026-01-21T16:20:49.035Z" },
-    { url = "https://files.pythonhosted.org/packages/66/4d/35352043ee0eaffdeff154fad67cd4a31dbed7ff8e3be1cc4549717d6d51/torch-2.10.0-cp314-cp314t-win_amd64.whl", hash = "sha256:71283a373f0ee2c89e0f0d5f446039bdabe8dbc3c9ccf35f0f784908b0acd185", size = 113995816, upload-time = "2026-01-21T16:22:05.312Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/e7/19894fdb51c7dbaf94f5a79bb0871da0992e8e4241e579cb006da46d2e58/torch-2.13.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:94f0de129916f77b8dc2c7a8eff644cfeddfe59e39c9f55e9f6e17543410281d", size = 111178962, upload-time = "2026-07-08T16:05:49.855Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/5c/b1d5de470c54e339b30a92d96683a71bcebd78f5f2a7fc714cd6dc6bbd68/torch-2.13.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:0ab4b69f3ee03a62a002cfbf77b1ca5e88aceb4ea64cb4388bb28f638ddbb045", size = 427198333, upload-time = "2026-07-08T16:05:36.847Z" },
+    { url = "https://files.pythonhosted.org/packages/50/c0/68a84105e1fcb8970144b388ff3d3e5dc15a3be28c1e247841f7d7247e41/torch-2.13.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:c78b7b4d04461855a764cf01bae9a462bb88bc93defcfa11235cbc8fdf3e12c4", size = 526555154, upload-time = "2026-07-08T16:05:06.507Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/c9/0bb9d097b03cbaf96bb75b15e867347b8e41bfcdfe0539452d17d9e63993/torch-2.13.0-cp310-cp310-win_amd64.whl", hash = "sha256:2bd30b6b730d987fa386ce3898933762c5cb8cc82eb0535211d787cc3ce2dfeb", size = 122015602, upload-time = "2026-07-08T16:05:45.25Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/fe/cba54dc58523434919b66f13a667e36e436deddd77ca519e96553617d4ec/torch-2.13.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:e76f9bcecc52b8ff711239a2f7547d5353df95878ab232f0773c1d95928b92f8", size = 111187938, upload-time = "2026-07-08T16:05:17.065Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/59/1e3160e18e12aa3038390efab3ce02b36a9d4d6a527ecdd8520dca2e68d8/torch-2.13.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:092790c696a760c729fd5722835f50b9d81fd7c8f141571f3f3cf4081a8f664c", size = 427199369, upload-time = "2026-07-08T16:04:51.054Z" },
+    { url = "https://files.pythonhosted.org/packages/01/79/1f2d34ad7034ee1c7ffc1cf8bf0f8213af2a81df6ecdb3997ecec107c09d/torch-2.13.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:60fcdcb2f3876e21146cb4524ef06397d727ca9ad5f020818547e25075fe3cb7", size = 526574961, upload-time = "2026-07-08T16:04:07.075Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fd/0f2ce40f58aefbdb3392f9acce3c8171940943ae2d661f70558bfa73befb/torch-2.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:a0d8b11f16a48d60e2015d8213aa0390744cbebb98e58b62b3514dddc656e330", size = 122015870, upload-time = "2026-07-08T16:05:27.59Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/3a/ed0f4d4d1dcde03bced7aac9a28e800abcdc0cbd06b6775044c9fbd877b7/torch-2.13.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2fe228aba290d14b9f31b049be550dbd469c3fd3013d7a19705b30454da97027", size = 111213045, upload-time = "2026-07-08T16:05:22.997Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a9/f6a2a4d763ff1df02e9a64c477029db614295bc9367f4131223791ccc243/torch-2.13.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:572df8be8ffb4599c88cbd6a0726f1f854f4da65d2e3c09f0e2c2283333cd6d4", size = 427210998, upload-time = "2026-07-08T16:04:37.708Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/82/fea946351658e6534db52d2cc12bc53087cbf87f9440c5f180f367c1950b/torch-2.13.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:796633c4cdf0fe2cdced72d8f88f22e73dbcfce83132763162f6d4bff13b820b", size = 526605292, upload-time = "2026-07-08T16:04:22.81Z" },
+    { url = "https://files.pythonhosted.org/packages/21/d6/e8f3c6f7e01f626f77259de9860d2a78bc84c40539e28e79b7e98b0bb659/torch-2.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:024c6cc0c1b085f2f91f20a3dc27b0471d021c31ce84b81be3afdc39f791fd9d", size = 122057313, upload-time = "2026-07-08T16:03:53.43Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fa/c1c10b7aff4a9a3e8956d4f0a5f468fa6db7abc3208805719076772b4833/torch-2.13.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:33449899ce5496c1b84b4853179d94fd102028ae1407314d9fb956bb79e70d09", size = 111213743, upload-time = "2026-07-08T16:03:28.579Z" },
+    { url = "https://files.pythonhosted.org/packages/11/18/9ecb37b56293a0be8d80f810bf672a72fe7e02f8b475d5ef1b9bf8a0d748/torch-2.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:1e09d6a722504957c694faceca843acde562786df1144ebcc5a74075ec7f6005", size = 427213008, upload-time = "2026-07-08T16:03:44.106Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5a/7c50ba1b7b713d71d34669c6d13dab0a11531a3eceb0307a5162dbfec0f7/torch-2.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a3a9a21312872af8a26950b2c15680335a386a1f56ed03e780653d78b9607e9e", size = 526602329, upload-time = "2026-07-08T16:03:12.649Z" },
+    { url = "https://files.pythonhosted.org/packages/91/3d/e7adcc6aaf36961cd18f56cf8ad0f3058c3a5c84ccf391762176c94581b8/torch-2.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:49b58f1e2c52440abb6f17c28f0335fe6c6d01ad1a7f55b0183b81e4b34d64e6", size = 122057920, upload-time = "2026-07-08T16:03:01.808Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/6dcc7f0c07052102dd36f83cbc5800842a909c8c3fbf1a7f8a5844954de9/torch-2.13.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d849b390e07d8d333ce8ecaf91b273c656c598379a19c9acf1318a883f6b391c", size = 111227066, upload-time = "2026-07-08T16:03:33.6Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/09/2c10e8cd0e00fa5d23c052df6ce467eaa7182399f5e0f824f1e4ff42ccae/torch-2.13.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:a3893dc2da0a972a8ca5d698c85a9f967559ac5f8ee1797b77408aa8734d073c", size = 427226309, upload-time = "2026-07-08T16:02:53.127Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c6/22c2102bbef14ca6a6cb4c20e42f088e49c5f812be4e160ae57502e325f9/torch-2.13.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:49f1ea385c754e54919408a9bb3b5a72b0b755bbe2c916c1d6f70afbec4908a2", size = 526614507, upload-time = "2026-07-08T16:02:16.441Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0c/7d1deb6bce5bc3e6042caf39100ac768eba3b9a098e1dddd16f75bd6489b/torch-2.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:4f8573e3ce9ebcd53fe922f01077a6085ccdfbe5f12fd215883a9d87d7a744fd", size = 122051871, upload-time = "2026-07-08T16:03:23.521Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ce/aa8b7f9949d32e0f2f624f342bc3b48112c1b8a130288465938bc83bcbf9/torch-2.13.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:c28def70706c2f9ecc752574766e8ae4da9b810ab6676b611166761a78a9f1e1", size = 111537025, upload-time = "2026-07-08T16:02:44.28Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d1/491e3a0389430946145888b0203f2b6a759ce2a61481b96a85c2da4f2ced/torch-2.13.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:31061ff56ed8fbf26c749806905aeb749ebeb819810fd5d52508aa5afd90dddc", size = 427219769, upload-time = "2026-07-08T16:02:31.18Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/1d/38006e045bf0a1fc28ef01e757c554e59e59a8770c284bc4f47b14e60441/torch-2.13.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:cc26eead4cf51d0b544e31e364dcf000846549c273bd148936fe9d24d29acb92", size = 526571320, upload-time = "2026-07-08T16:01:59.348Z" },
+    { url = "https://files.pythonhosted.org/packages/56/94/655c91992a882bd5071aa0b5d22a07dbb130d801e872be97c0b627a7c693/torch-2.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a7de8a313090dc5c7d7ba4bfe5c3be222528f9a4dba1acc83bddb1157360c4b8", size = 122306773, upload-time = "2026-07-08T16:02:39.832Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.15.0.dev20260830"
+source = { registry = "https://download.pytorch.org/whl/nightly/cpu" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+]
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version == '3.12.*'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or python_full_version >= '3.13'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/nightly/cpu/torch-2.15.0.dev20260830-cp310-cp310-macosx_14_0_arm64.whl", upload-time = "2026-08-30T15:52:32Z" },
+    { url = "https://download-r2.pytorch.org/whl/nightly/cpu/torch-2.15.0.dev20260830-cp311-cp311-macosx_14_0_arm64.whl", upload-time = "2026-08-30T15:52:03Z" },
+    { url = "https://download-r2.pytorch.org/whl/nightly/cpu/torch-2.15.0.dev20260830-cp312-cp312-macosx_14_0_arm64.whl", upload-time = "2026-08-30T15:53:00Z" },
+    { url = "https://download-r2.pytorch.org/whl/nightly/cpu/torch-2.15.0.dev20260830-cp313-cp313-macosx_14_0_arm64.whl", upload-time = "2026-08-30T15:52:08Z" },
+    { url = "https://download-r2.pytorch.org/whl/nightly/cpu/torch-2.15.0.dev20260830-cp314-cp314-macosx_14_0_arm64.whl", upload-time = "2026-08-30T15:52:33Z" },
+    { url = "https://download-r2.pytorch.org/whl/nightly/cpu/torch-2.15.0.dev20260830-cp314-cp314t-macosx_14_0_arm64.whl", upload-time = "2026-08-30T15:53:03Z" },
+    { url = "https://download-r2.pytorch.org/whl/nightly/cpu/torch-2.15.0.dev20260830-cp315-cp315-macosx_14_0_arm64.whl", upload-time = "2026-08-30T15:52:30Z" },
+    { url = "https://download-r2.pytorch.org/whl/nightly/cpu/torch-2.15.0.dev20260830-cp315-cp315t-macosx_14_0_arm64.whl", upload-time = "2026-08-30T15:52:32Z" },
 ]
 
 [[package]]
 name = "torchrl"
-version = "0.11.1"
-source = { registry = "https://pypi.org/simple" }
+version = "0.14.0+gb24feae9"
+source = { git = "https://github.com/pytorch/rl.git?branch=main#b24feae9e28e8e18e64d970a3eab8d4a3d1010c9" }
 dependencies = [
     { name = "cloudpickle" },
+    { name = "hoptorch" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "packaging" },
     { name = "pyvers" },
     { name = "tensordict" },
-    { name = "torch" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/a5/bfd7fc572751058b1fbc78e7e812538eb46c697b21a5f5af4db1239dc6fb/torchrl-0.11.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:68a6dbbed25ba4205df1e847aa46f7a6f2c82c970a8fb687b743f4abf81d195d", size = 2403325, upload-time = "2026-02-05T08:40:56.679Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/f4/bd792f1bb2512ae909921a34beef126a8c7febf15e278c348fe2286cba1d/torchrl-0.11.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:0feb34545c1084cb552404e9b021f4c17f95b2628d33c256563495e53dc0d206", size = 2067199, upload-time = "2026-02-05T08:40:59.003Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/bc/976b00c3a3cd9808f6e711e98f96514d15858acf4e0c6e286c6ae8549bb8/torchrl-0.11.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:99808050cd5ad85d55dd8fab74c196ff0caa5035ba9f98e2e5838e0e7526466c", size = 2080387, upload-time = "2026-02-05T08:41:01.206Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/97/e4097e0e9f6782fcf9e6f002708c2fd5bcbdd6f9589b4c64ef94d6018957/torchrl-0.11.1-cp310-cp310-win_amd64.whl", hash = "sha256:a01b2ff1e2df92ac30f939b67b9a2a7097451a2bd0f9be4999f1ff57948bd79c", size = 2024302, upload-time = "2026-02-05T08:41:02.696Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/31/9e6f9a4c585d5c2047c279204a8f145ad516be956fdde07168f96eddd6a3/torchrl-0.11.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0b5239791fc2a7011119784e162234a9e6fa0c6356176e51f59b6187398a6b8c", size = 2404777, upload-time = "2026-02-05T08:41:04.72Z" },
-    { url = "https://files.pythonhosted.org/packages/28/94/28f099870dd1278133f47fad0f07a4669f8438fc7b5f1fe4c8e66df2d05a/torchrl-0.11.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:2c059b7653b212ea72475f88cb82f8e59c7b0294c087c8d76241f660bdc25a64", size = 2070166, upload-time = "2026-02-05T08:41:06.97Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/20/4adb692fb11fd10d03675b06f4405365b5aa0711ff7ef0332dbc2d152a43/torchrl-0.11.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:74b245381555406e7b3658f249306478833843059e95318875616294a04487cb", size = 2079393, upload-time = "2026-02-05T08:41:08.501Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/df/0bb99793b63c4c03fbfbd5e3f77ea12edcede117c84a988b144c9c772daf/torchrl-0.11.1-cp311-cp311-win_amd64.whl", hash = "sha256:f92b3b31d6d0a949f243ebd1666dd995f0039c9b9d32bed3d5266de47112d24a", size = 2025181, upload-time = "2026-02-05T08:41:10.489Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/99/87021c03312e717371183e86cdaf259b89e266c087bfac93bb86caaa268f/torchrl-0.11.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a991ebc62be32b801d8668fc0ab094519bfa1b4266dc9955f78fed735f333674", size = 2405617, upload-time = "2026-02-05T08:41:12.213Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/36/10e11087065010ed55bfb67725693342336e9c62d8c03f19ec57898546f0/torchrl-0.11.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:a0a0bbf524db1d7ef910aa12b3fad82a3ff737cdf4d40a191c21911b1f5104f2", size = 2067025, upload-time = "2026-02-05T08:41:13.756Z" },
-    { url = "https://files.pythonhosted.org/packages/78/8a/9c34e438219df53d983dddc824dad47735cbfe929c582038094a7d2d57d1/torchrl-0.11.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:de87f1b9e4f8d5ed803fdf0a4f147200c894c3ddea609f22257020fbffb34396", size = 2078712, upload-time = "2026-02-05T08:41:15.274Z" },
-    { url = "https://files.pythonhosted.org/packages/20/b3/9969d77db3224d13b73383e22e15ed9cd7517c3d87eb8edad88c7c95ae1c/torchrl-0.11.1-cp312-cp312-win_amd64.whl", hash = "sha256:381e485b1cef07cbf4f847f9368f957d5a73fd5fb03cb54157da73b9c7332cfe", size = 2026201, upload-time = "2026-02-05T08:41:16.828Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/c5/5a79490271eea9fb0c952db88579b1fba081319caa3416416e4b32468fdd/torchrl-0.11.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:29ec01224aa792e3213a67167313e6abcefef0bdc83d2654ce6612b591e3f9a5", size = 2405505, upload-time = "2026-02-05T08:41:18.985Z" },
-    { url = "https://files.pythonhosted.org/packages/48/9b/e90541a545104472c6a1d1052a0402f7e84edba8eba06e1f45281032acb6/torchrl-0.11.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:f28fdcc0f3f21ea7e469eef10145d6b3dfd9132496bad628c7d859a7b6e52758", size = 2067205, upload-time = "2026-02-05T08:41:21.075Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/a4/eaa60adda7be941b3edb4868d95478b2204521eb49c0364756e133c7e0e1/torchrl-0.11.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:020ac8516ce78e5d3b47a9f1177302de508af6595edfd762ff5ddbf57cf82b7d", size = 2078786, upload-time = "2026-02-05T08:41:23.044Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/85/c06fb51ae249e417f9709fb5d03dd4a088592f04fd7cdb540d8ee41db082/torchrl-0.11.1-cp313-cp313-win_amd64.whl", hash = "sha256:583f4ebcc4cd5a6d8b22f9db209acabd8b6f0280e8e72218237ebecd77b62bf7", size = 2026166, upload-time = "2026-02-05T08:41:25.093Z" },
-    { url = "https://files.pythonhosted.org/packages/52/7d/a3f45c4dad7cf5b03f4e83a2b28f58d3bc9e09be1478a50c3cb6d584cfdf/torchrl-0.11.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:bf4fa8baea191a66f2319f2b95f4ff64643340f87ab57d7d73060bc655ee8ce2", size = 2416912, upload-time = "2026-02-05T08:41:27.566Z" },
-    { url = "https://files.pythonhosted.org/packages/57/85/b92223d8766ba5376a57a5c254daf340d3cdbc732dc0922e558f771a99e3/torchrl-0.11.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:ea7f8a2fe8785f5e12c19e91a3838bef59bc3e64533e7b73629ad9de4117d628", size = 2069297, upload-time = "2026-02-05T08:41:29.175Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/53/4b87fc91785b2b9bb9efb451ea44d8fe159e25ad96a47166b20a58e687ad/torchrl-0.11.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:a114f19d85050ae9c80299a3d141dd8159a30a8466bef4be94a74e7c555cadec", size = 2078119, upload-time = "2026-02-05T08:41:30.844Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/d5/2ba34332cf88a74910cdedf6910c99a2cae1dbc955fce4a84d14e7b03355/torchrl-0.11.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a8176fda648d2a734069a6a881ed1e383e1ff98b552d87159132c102696fde8e", size = 2039255, upload-time = "2026-02-05T08:41:32.926Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/42/cb133b3b12152af903dffeb0955f314e472d3eabb7baa1a8eb2176a7fb21/torchrl-0.11.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d335957a5ed16e2cf5133c2a0b877d2fbd0a942d1e5febe4abf40a1fc8a0049b", size = 2406453, upload-time = "2026-02-05T08:41:35.227Z" },
-    { url = "https://files.pythonhosted.org/packages/85/2a/30bc2d00e050a0672beb599bf5c8630a92ae56ae992975c119167071f854/torchrl-0.11.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:0e1dc505a290c358d7f970b4c7b563e2f6ed1a66b8be2e02d256bf5400f378ce", size = 2067576, upload-time = "2026-02-05T08:41:37.239Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/e2/c7f0d83c43c533ba7d4489841631ec91305380ee580d7cd13d5f4fbc7a8d/torchrl-0.11.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:9340df4cbd29d960075b97a0c2deba5f5f6c35e676ac6152703311cb507c1249", size = 2078922, upload-time = "2026-02-05T08:41:39.173Z" },
-    { url = "https://files.pythonhosted.org/packages/da/13/8618422952ff2df224fca07a4bbf15ebfb242d9b78348cb09834115003a9/torchrl-0.11.1-cp314-cp314-win_amd64.whl", hash = "sha256:bb831b52630aa1ae873ca349c40c0e2990d3862fc7a75b3d879ce79583628d9d", size = 2026275, upload-time = "2026-02-05T08:41:40.968Z" },
-    { url = "https://files.pythonhosted.org/packages/df/c6/0acd65d89557d3617db6d9e75de9cd5a430dcd9009b981a22681664690be/torchrl-0.11.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:64ac7e97650524315392b49c911165ec8feee463fc830d3ff1714c8adc2b729f", size = 2416905, upload-time = "2026-02-05T08:41:42.669Z" },
-    { url = "https://files.pythonhosted.org/packages/46/3d/2f19cddab62cb8dc0a2e2a5053d6c100c9c1c4aa2b436de91a4e0e73c2bc/torchrl-0.11.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d313a7c975aeb682df63309254fab58a6e025aa22afab5730746a50564a22707", size = 2069297, upload-time = "2026-02-05T08:41:44.353Z" },
-    { url = "https://files.pythonhosted.org/packages/53/57/3d551d13f0bd04451d00c43945474454a27f5bfb2bd286023937c2efe3cc/torchrl-0.11.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:750acfc08d606434397460c34ddd4fb8debe1ffc525a0b8036f1ea7f0f9b2278", size = 2078120, upload-time = "2026-02-05T08:41:45.827Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/23/165348e9502dc7004080a0ba6364d414826ca282c951fc36cbbb3e1fa8b6/torchrl-0.11.1-cp314-cp314t-win_amd64.whl", hash = "sha256:96a6bcb6325a983a1ef15a6c0d5be012c4588bfb5d65735b9f00af0a2bdeb844", size = 2026283, upload-time = "2026-02-05T08:41:47.86Z" },
+    { name = "torch", version = "2.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' or sys_platform != 'darwin'" },
+    { name = "torch", version = "2.15.0.dev20260830", source = { registry = "https://download.pytorch.org/whl/nightly/cpu" }, marker = "python_full_version != '3.12.*' and sys_platform == 'darwin'" },
 ]
 
 [[package]]
@@ -1276,16 +1333,21 @@ wheels = [
 
 [[package]]
 name = "triton"
-version = "3.6.0"
+version = "3.7.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/f7/f1c9d3424ab199ac53c2da567b859bcddbb9c9e7154805119f8bd95ec36f/triton-3.6.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a6550fae429e0667e397e5de64b332d1e5695b73650ee75a6146e2e902770bea", size = 188105201, upload-time = "2026-01-20T16:00:29.272Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/12/b05ba554d2c623bffa59922b94b0775673de251f468a9609bc9e45de95e9/triton-3.6.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8e323d608e3a9bfcc2d9efcc90ceefb764a82b99dea12a86d643c72539ad5d3", size = 188214640, upload-time = "2026-01-20T16:00:35.869Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/a8/cdf8b3e4c98132f965f88c2313a4b493266832ad47fb52f23d14d4f86bb5/triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74caf5e34b66d9f3a429af689c1c7128daba1d8208df60e81106b115c00d6fca", size = 188266850, upload-time = "2026-01-20T16:00:43.041Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/0b/37d991d8c130ce81a8728ae3c25b6e60935838e9be1b58791f5997b24a54/triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c7f76c6e72d2ef08df639e3d0d30729112f47a56b0c81672edc05ee5116ac9", size = 188289450, upload-time = "2026-01-20T16:00:49.136Z" },
-    { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296, upload-time = "2026-01-20T16:00:56.042Z" },
-    { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload-time = "2026-01-20T16:01:07.278Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload-time = "2026-01-20T16:01:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ea/629cc37436ca5df93ce98956d09cd2ca1498bfee8ef4972d2fe48b9f958c/triton-3.7.1-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3daf64305d6cea88d3334c65ebc9bcd0c64c9564a977084366aa768d57cbcf64", size = 184551013, upload-time = "2026-06-17T20:03:37.551Z" },
+    { url = "https://files.pythonhosted.org/packages/15/76/c79c34311625227a288df3e483fc5cdf3d596624cbd4b4758c4cbdc14af3/triton-3.7.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ee89fbf782ec2ad50391dd1cf26cbea4f4467154c37f4773026da8fc31c0f58e", size = 197596267, upload-time = "2026-06-17T19:53:06.898Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/f9/19d842d06a08559534fa1eaab6ca551b1bcf40f06620bddec1babaa2772d/triton-3.7.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4a0e1cd4c4a76370ed74a8432a53cea28716827d19e40ffc732233e35ceb3f6", size = 184664887, upload-time = "2026-06-17T20:03:42.913Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/5e/fce69606f7f240297f163e25539906732b199530d486ce67ae319877e821/triton-3.7.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6744957e9fd610a29680ec2346057d0c86948ed3812468670719f391e94b44a5", size = 197701306, upload-time = "2026-06-17T19:53:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/94/fa/f856e24deb462d5f18bd4b5a746957862ab9b6ee5834bda60605ec348366/triton-3.7.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9497f2e696ee368862a181a90b2dcc03ca978cc4f602abd67c7d81022a6988e1", size = 184692359, upload-time = "2026-06-17T20:03:48.288Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/6f/fb96d15db6f36d6eae4cafb998c2e0353bf59d7c4ea1662d7497f269134a/triton-3.7.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e40869937a68206ec70d7f25bb7ec6433cb083f9135e1f36dbd318dc449a728", size = 197719725, upload-time = "2026-06-17T19:53:20.419Z" },
+    { url = "https://files.pythonhosted.org/packages/00/42/c5089d4d9327fcd1e862c599cc2927f39418f84dd11a84cb2ccff9d4787a/triton-3.7.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cdbfc09d9ec58bc5e68321525653220de7515c199e7a8097a97c85e62b52cd0a", size = 184694629, upload-time = "2026-06-17T20:03:53.444Z" },
+    { url = "https://files.pythonhosted.org/packages/07/42/2c3ac59253ae8892b6f307875263dd23dc875cdf732d3aea40d6d41fb7cb/triton-3.7.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:58c0e131da05134a2a4788ccbcc0c1105cf0f54c8e98f19e34cd465396dc15eb", size = 197729241, upload-time = "2026-06-17T19:53:27.801Z" },
+    { url = "https://files.pythonhosted.org/packages/40/71/e01aa7ad573883ed9456f130226babdec70b005e098c4d6226a6238e761b/triton-3.7.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fe4ea396a06171f1f1f58cbd39c70b09294398f7dd7c620939bab54ad6f934fa", size = 184705764, upload-time = "2026-06-17T20:03:59.064Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/09/5683146fda6a2b569deb78ccfd8fbfea8bfe55f726b081c0a6bb18dd6f28/triton-3.7.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2020153b08280415ec0da6607834e79166442147e78e144df06b508c75b186d2", size = 197729537, upload-time = "2026-06-17T19:53:35.516Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f8/448220c3092019f9fdfab39ec47985968181d67da34b44f6a7f6280a5cbb/triton-3.7.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c58e4c61f0c73b5dba3b5d19b4a7093c32f90dc18b2a7f121a7c16ccd31107b7", size = 184814760, upload-time = "2026-06-17T20:04:04.984Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ac/229b7d4589d2e5937310e72c6d46e89599d16a4a12b479ffa1499fee8eb8/triton-3.7.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10ba85fa2cca4a2fbdeb36bf1cb082f2c252bda55bf9fccd74f65ec5bc647e68", size = 197824404, upload-time = "2026-06-17T19:53:42.772Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- keep the runtime requirement at MuJoCo >= 3.3 with no upper version bound
- require TensorDict >= 0.14.0 for the core and TorchRL >= 0.14.0 for the optional zoo, without upper caps
- make the development lockfile follow TensorDict main and TorchRL main as an aligned pair
- install rolling TensorDict and TorchRL together in compatibility CI, and install their latest stable releases together on release branches and in wheel smoke tests
- add named MuJoCo 3.11 and 3.12 jobs while retaining the unpinned current job for future releases
- preserve the metadata-aware TensorClass representations for constraints, contacts, models, and data
- route functorch solver loops directly through the registered higher-order operator, with PyTree flattening confined to that compiler adapter boundary
- precompute compact body-to-DoF chains so Jacobian construction stays compatible with the current compiler stack
- correct the upstream tracker: PyTorch #175525 and #175852 closed without merging, while #176977 landed

## Validation

With MuJoCo 3.12.0, mujoco-mjx 3.12.0, PyTorch 2.13.0, TensorDict 0.14.0+g9777798, and TorchRL 0.14.0+gb24feae9:

- 46 focused TensorClass, TorchRL zoo, constraint, solver, and constrained HalfCheetah vmap tests passed
- 167 enum, device conversion, Jacobian, constraint, collision, forward, smooth-dynamics, vmap, and fullgraph regression tests passed
- constrained HalfCheetah vmap parity passed both without and with action sequences
- 72 focused solver, constraint, and forward tests passed
- the built wheel declares `tensordict>=0.14.0` and `torchrl>=0.14.0` for the zoo extra
- the uv lock is current and Ruff formatting and lint checks pass
- no CUDA validation was performed

CI exercises the same rolling TensorDict/TorchRL pair at the MuJoCo lower bound and against the unpinned current MuJoCo release. The full main-branch matrix retains explicit MuJoCo 3.3 through 3.12 coverage.
